### PR TITLE
feat/docker-postgres-local-setup: 支持本地通过 Docker Compose 一键启动 PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # Aranya-CRM
 This is a CRM system for Aranya orgnization
+
+## Local PostgreSQL (Docker Compose)
+
+PostgreSQL is managed in `infra/docker/docker-compose.yaml` with fixed local dev credentials:
+
+- Database: `aranya_crm`
+- Username: `aranya_admin`
+- Password: `aranya_secret`
+- Port: `5432` (bind `127.0.0.1:5432`)
+- Data volume: `aranya_postgres_data`
+
+Start database:
+
+```powershell
+docker compose -f infra/docker/docker-compose.yaml up -d
+```
+
+Stop database:
+
+```powershell
+docker compose -f infra/docker/docker-compose.yaml down
+```
+
+Reset database (drop volume and recreate a clean empty DB):
+
+```powershell
+docker compose -f infra/docker/docker-compose.yaml down -v
+docker compose -f infra/docker/docker-compose.yaml up -d
+```
+
+Backend uses `backend/src/main/resources/application.yml`:
+
+- Default local URL: `jdbc:postgresql://localhost:5432/aranya_crm`
+- JPA schema mode: `spring.jpa.hibernate.ddl-auto=update`
+
+If backend is later containerized in the same Compose network, run backend with:
+
+- `DB_HOST=postgres`
+- `DB_PORT=5432`
+

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    # Local IDE run uses localhost; in Docker-to-Docker mode set DB_HOST=postgres.
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/aranya_crm
+    username: aranya_admin
+    password: aranya_secret
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+  liquibase:
+    enabled: false
+

--- a/infra/docker/docker-compose.yaml
+++ b/infra/docker/docker-compose.yaml
@@ -1,20 +1,20 @@
 # Docker Compose configuration for Aranya's PostgreSQL database
 services:
-  db:
+  postgres:
     image: postgres:17
     container_name: aranya-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: aranya_crm
+      POSTGRES_USER: aranya_admin
+      POSTGRES_PASSWORD: aranya_secret
       TZ: Asia/Singapore
     ports:
       - "127.0.0.1:5432:5432"
     volumes:
       - aranya_postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      test: ["CMD-SHELL", "pg_isready -U aranya_admin -d aranya_crm"]
       interval: 10s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
- 在 infra/docker/docker-compose.yaml 中硬编码本地开发库名、账号与密码（aranya_crm / aranya_admin / aranya_secret）
- 保留命名卷 aranya_postgres_data，实现数据持久化
- 增加 PostgreSQL healthcheck，确保数据库就绪状态可观测
- 新增 backend/src/main/resources/application.yml，配置本地数据源与 JPA ddl-auto=update
- 更新 README.md，补充启动、停止、清库重建（down -v）及连接说明