### PR TITLE
feat: implement TOTP-based two-factor authentication

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -74,6 +74,13 @@
             <artifactId>liquibase-core</artifactId>
         </dependency>
 
+        <!-- TOTP (2FA) -->
+        <dependency>
+            <groupId>dev.samstevens.totp</groupId>
+            <artifactId>totp</artifactId>
+            <version>1.7.1</version>
+        </dependency>
+
         <!-- Swagger / OpenAPI -->
         <dependency>
             <groupId>org.springdoc</groupId>

--- a/backend/src/main/java/aranya/crm/AranyaCrmApplication.java
+++ b/backend/src/main/java/aranya/crm/AranyaCrmApplication.java
@@ -7,9 +7,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 @SpringBootApplication
 public class AranyaCrmApplication {
     public static void main(String[] args) {
-        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
-        System.out.println(encoder.encode("password"));
-
         SpringApplication.run(AranyaCrmApplication.class, args);
     }
 }

--- a/backend/src/main/java/aranya/crm/config/AppProperties.java
+++ b/backend/src/main/java/aranya/crm/config/AppProperties.java
@@ -13,6 +13,7 @@ public class AppProperties {
 
     private CorsProperties cors = new CorsProperties();
     private JwtProperties jwt = new JwtProperties();
+    private TwoFactorProperties twoFactor = new TwoFactorProperties();
 
     @Data
     public static class CorsProperties {
@@ -24,5 +25,12 @@ public class AppProperties {
         private String secret;
         private long accessTokenExpiration;
         private long refreshTokenExpiration;
+    }
+
+    @Data
+    public static class TwoFactorProperties {
+        private String issuer = "AranyaCRM";
+        private long tempTokenExpiration = 300000L;
+        private String encryptionKey;
     }
 }

--- a/backend/src/main/java/aranya/crm/controller/TwoFactorController.java
+++ b/backend/src/main/java/aranya/crm/controller/TwoFactorController.java
@@ -1,0 +1,55 @@
+package aranya.crm.controller;
+
+import aranya.crm.dto.*;
+import aranya.crm.security.model.UserPrincipal;
+import aranya.crm.service.AuthService;
+import aranya.crm.service.TwoFactorService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth/2fa")
+@RequiredArgsConstructor
+public class TwoFactorController {
+
+    private final TwoFactorService twoFactorService;
+    private final AuthService authService;
+
+    @GetMapping("/setup")
+    public ResponseEntity<TwoFactorSetupResponse> setup(
+            @AuthenticationPrincipal UserPrincipal principal) {
+        return ResponseEntity.ok(twoFactorService.generateSetup(principal.getEmail()));
+    }
+
+    @PostMapping("/enable")
+    public ResponseEntity<BackupCodesResponse> enable(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody TwoFactorEnableRequest request) {
+        return ResponseEntity.ok(
+                new BackupCodesResponse(twoFactorService.enableTwoFactor(principal.getId(), request)));
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<LoginResponse> verify(
+            @Valid @RequestBody TwoFactorVerifyRequest request) {
+        return ResponseEntity.ok(authService.verifyTwoFactor(request));
+    }
+
+    @PostMapping("/disable")
+    public ResponseEntity<Void> disable(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody TwoFactorDisableRequest request) {
+        twoFactorService.disableTwoFactor(principal.getId(), request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/backup-codes")
+    public ResponseEntity<BackupCodesResponse> regenerateBackupCodes(
+            @AuthenticationPrincipal UserPrincipal principal) {
+        return ResponseEntity.ok(
+                new BackupCodesResponse(twoFactorService.regenerateBackupCodes(principal.getId())));
+    }
+}

--- a/backend/src/main/java/aranya/crm/dto/BackupCodesResponse.java
+++ b/backend/src/main/java/aranya/crm/dto/BackupCodesResponse.java
@@ -1,0 +1,12 @@
+package aranya.crm.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class BackupCodesResponse {
+    private List<String> codes;
+}

--- a/backend/src/main/java/aranya/crm/dto/LoginResponse.java
+++ b/backend/src/main/java/aranya/crm/dto/LoginResponse.java
@@ -12,4 +12,6 @@ public class LoginResponse {
     private long expiresIn;
     private String email;
     private String fullName;
+    private Boolean requiresTwoFactor;
+    private String tempToken;
 }

--- a/backend/src/main/java/aranya/crm/dto/TwoFactorDisableRequest.java
+++ b/backend/src/main/java/aranya/crm/dto/TwoFactorDisableRequest.java
@@ -1,0 +1,14 @@
+package aranya.crm.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class TwoFactorDisableRequest {
+
+    @NotBlank
+    private String password;
+
+    @NotBlank
+    private String code;
+}

--- a/backend/src/main/java/aranya/crm/dto/TwoFactorEnableRequest.java
+++ b/backend/src/main/java/aranya/crm/dto/TwoFactorEnableRequest.java
@@ -1,0 +1,16 @@
+package aranya.crm.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class TwoFactorEnableRequest {
+
+    @NotBlank
+    private String secret;
+
+    @NotBlank
+    @Size(min = 6, max = 6, message = "Code must be 6 digits")
+    private String code;
+}

--- a/backend/src/main/java/aranya/crm/dto/TwoFactorSetupResponse.java
+++ b/backend/src/main/java/aranya/crm/dto/TwoFactorSetupResponse.java
@@ -1,0 +1,11 @@
+package aranya.crm.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class TwoFactorSetupResponse {
+    private String secret;
+    private String qrCodeUri;
+}

--- a/backend/src/main/java/aranya/crm/dto/TwoFactorVerifyRequest.java
+++ b/backend/src/main/java/aranya/crm/dto/TwoFactorVerifyRequest.java
@@ -1,0 +1,14 @@
+package aranya.crm.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class TwoFactorVerifyRequest {
+
+    @NotBlank
+    private String tempToken;
+
+    @NotBlank
+    private String code;
+}

--- a/backend/src/main/java/aranya/crm/entity/TwoFactorBackupCode.java
+++ b/backend/src/main/java/aranya/crm/entity/TwoFactorBackupCode.java
@@ -1,0 +1,36 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "two_factor_backup_code")
+public class TwoFactorBackupCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "code_hash", nullable = false, length = 64)
+    private String codeHash;
+
+    @Column(nullable = false)
+    private boolean used = false;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/aranya/crm/entity/User.java
+++ b/backend/src/main/java/aranya/crm/entity/User.java
@@ -32,9 +32,14 @@ public class User {
     @Column(name = "password_hash", nullable = false, length = 255)
     private String passwordHash;
 
-    // 建议用枚举管理状态，避免魔法字符串
     @Column(nullable = false, length = 20)
     private String status = "ACTIVE";
+
+    @Column(name = "two_factor_enabled", nullable = false)
+    private boolean twoFactorEnabled = false;
+
+    @Column(name = "two_factor_secret", length = 512)
+    private String twoFactorSecret;
 
 
     // 一个用户对应多个 user_role 记录

--- a/backend/src/main/java/aranya/crm/repository/TwoFactorBackupCodeRepository.java
+++ b/backend/src/main/java/aranya/crm/repository/TwoFactorBackupCodeRepository.java
@@ -1,0 +1,18 @@
+package aranya.crm.repository;
+
+import aranya.crm.entity.TwoFactorBackupCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface TwoFactorBackupCodeRepository extends JpaRepository<TwoFactorBackupCode, Long> {
+
+    Optional<TwoFactorBackupCode> findByUserIdAndCodeHashAndUsedFalse(Long userId, String codeHash);
+
+    @Modifying
+    @Query("DELETE FROM TwoFactorBackupCode b WHERE b.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
+}

--- a/backend/src/main/java/aranya/crm/security/config/SecurityConfig.java
+++ b/backend/src/main/java/aranya/crm/security/config/SecurityConfig.java
@@ -34,7 +34,9 @@ public class SecurityConfig {
 
     private static final String[] PUBLIC_ENDPOINTS = {
             "/api/dashboard",
-            "/api/v1/auth/**",
+            "/api/v1/auth/login",
+            "/api/v1/auth/refresh",
+            "/api/v1/auth/2fa/verify",
             "/v3/api-docs/**",
             "/swagger-ui/**",
             "/swagger-ui.html",

--- a/backend/src/main/java/aranya/crm/security/filter/JwtAuthFilter.java
+++ b/backend/src/main/java/aranya/crm/security/filter/JwtAuthFilter.java
@@ -34,7 +34,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         String path = request.getRequestURI();
         // 公开接口不需要经过 JWT 过滤器
         boolean skip = path.equals("/api/v1/auth/login") ||
-                path.equals("/api/v1/auth/refresh");
+                path.equals("/api/v1/auth/refresh") ||
+                path.equals("/api/v1/auth/2fa/verify");
         log.debug("shouldNotFilter: path={}, skip={}", path, skip);
         return skip;
     }
@@ -56,9 +57,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         try{
             final String email = jwtUtil.extractEmail(token);
 
-            if (jwtUtil.isRefreshToken(token)) {
-                log.warn("Refresh token used as access token, request URI: {}", request.getRequestURI());
-                sendUnauthorized(response, "Refresh token cannot be used to access resources");
+            if (!jwtUtil.isAccessToken(token)) {
+                log.warn("Non-access token used on protected resource, URI: {}", request.getRequestURI());
+                sendUnauthorized(response, "Invalid token type for this request");
                 return;
             }
 

--- a/backend/src/main/java/aranya/crm/security/model/UserPrincipal.java
+++ b/backend/src/main/java/aranya/crm/security/model/UserPrincipal.java
@@ -18,6 +18,7 @@ public class UserPrincipal implements UserDetails {
     private final String fullName;
     private final String passwordHash;
     private final String status;
+    private final boolean twoFactorEnabled;
     private final Collection<? extends GrantedAuthority> authorities;
 
     private UserPrincipal(User user, List<String> roleNames){
@@ -26,6 +27,7 @@ public class UserPrincipal implements UserDetails {
         this.fullName = user.getFullName();
         this.passwordHash = user.getPasswordHash();
         this.status = user.getStatus();
+        this.twoFactorEnabled = user.isTwoFactorEnabled();
         this.authorities=roleNames.stream()
                 .map(role -> new SimpleGrantedAuthority("ROLE_"+role.toUpperCase()))
                 .collect(Collectors.toList());

--- a/backend/src/main/java/aranya/crm/security/util/JwtUtil.java
+++ b/backend/src/main/java/aranya/crm/security/util/JwtUtil.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.security.SecurityException;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
@@ -23,7 +24,8 @@ public class JwtUtil {
 
     public enum TokenType {
         ACCESS,
-        REFRESH
+        REFRESH,
+        TWO_FACTOR
     }
 
     private final AppProperties appProperties;
@@ -44,7 +46,24 @@ public class JwtUtil {
 
     public String generateRefreshToken(UserDetails userDetails) {
         return buildToken(userDetails.getUsername(),
-                appProperties.getJwt().getRefreshTokenExpiration(),TokenType.REFRESH);
+                appProperties.getJwt().getRefreshTokenExpiration(), TokenType.REFRESH);
+    }
+
+    public String generateTempToken(UserDetails userDetails) {
+        return buildToken(userDetails.getUsername(),
+                appProperties.getTwoFactor().getTempTokenExpiration(), TokenType.TWO_FACTOR);
+    }
+
+    public String extractEmailFromTempToken(String token) {
+        try {
+            Claims claims = extractClaims(token);
+            if (!TokenType.TWO_FACTOR.name().equals(claims.get("tokenType"))) {
+                throw new BadCredentialsException("Invalid temp token type");
+            }
+            return claims.getSubject();
+        } catch (JwtException e) {
+            throw new BadCredentialsException("Invalid or expired temp token");
+        }
     }
 
 
@@ -78,6 +97,11 @@ public class JwtUtil {
     public boolean isRefreshToken(String token){
         Claims claims = extractClaims(token);
         return TokenType.REFRESH.name().equals(claims.get("tokenType"));
+    }
+
+    public boolean isAccessToken(String token) {
+        Claims claims = extractClaims(token);
+        return TokenType.ACCESS.name().equals(claims.get("tokenType"));
     }
 
     private boolean isTokenExpired(String token) {

--- a/backend/src/main/java/aranya/crm/service/AuthService.java
+++ b/backend/src/main/java/aranya/crm/service/AuthService.java
@@ -3,6 +3,7 @@ package aranya.crm.service;
 import aranya.crm.config.AppProperties;
 import aranya.crm.dto.LoginRequest;
 import aranya.crm.dto.LoginResponse;
+import aranya.crm.dto.TwoFactorVerifyRequest;
 import aranya.crm.entity.RefreshToken;
 import aranya.crm.entity.User;
 import aranya.crm.repository.RefreshTokenRepository;
@@ -17,6 +18,7 @@ import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +39,7 @@ public class AuthService {
     private final AppProperties appProperties;
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
+    private final TwoFactorService twoFactorService;
 
     /**
      * 登录
@@ -45,16 +48,41 @@ public class AuthService {
      */
     @Transactional
     public LoginResponse login(LoginRequest loginRequest) {
-        Authentication authentication = authenticate(loginRequest.getEmail(),loginRequest.getPassword());
-
+        Authentication authentication = authenticate(loginRequest.getEmail(), loginRequest.getPassword());
         UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+
+        if (principal.isTwoFactorEnabled()) {
+            String tempToken = jwtUtil.generateTempToken(principal);
+            log.info("2FA required for userId: {}", principal.getId());
+            return LoginResponse.builder()
+                    .requiresTwoFactor(true)
+                    .tempToken(tempToken)
+                    .build();
+        }
 
         String accessToken = jwtUtil.generateAccessToken(principal);
         String refreshToken = jwtUtil.generateRefreshToken(principal);
-
-        saveRefreshToken(refreshToken,principal.getId());
+        saveRefreshToken(refreshToken, principal.getId());
         log.info("User logged in successfully, userId: {}", principal.getId());
+        return buildLoginResponse(accessToken, refreshToken, principal);
+    }
 
+    @Transactional
+    public LoginResponse verifyTwoFactor(TwoFactorVerifyRequest request) {
+        String email = jwtUtil.extractEmailFromTempToken(request.getTempToken());
+        UserPrincipal principal = (UserPrincipal) userDetailsService.loadUserByUsername(email);
+        User user = userRepository.findById(principal.getId())
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        if (!twoFactorService.verifyCodeForUser(user, request.getCode())) {
+            log.warn("Failed 2FA verification for userId: {}", principal.getId());
+            throw new BadCredentialsException("Invalid 2FA code");
+        }
+
+        String accessToken = jwtUtil.generateAccessToken(principal);
+        String refreshToken = jwtUtil.generateRefreshToken(principal);
+        saveRefreshToken(refreshToken, principal.getId());
+        log.info("2FA verified, user logged in, userId: {}", principal.getId());
         return buildLoginResponse(accessToken, refreshToken, principal);
     }
 

--- a/backend/src/main/java/aranya/crm/service/TwoFactorService.java
+++ b/backend/src/main/java/aranya/crm/service/TwoFactorService.java
@@ -1,0 +1,242 @@
+package aranya.crm.service;
+
+import aranya.crm.config.AppProperties;
+import aranya.crm.dto.TwoFactorDisableRequest;
+import aranya.crm.dto.TwoFactorEnableRequest;
+import aranya.crm.dto.TwoFactorSetupResponse;
+import aranya.crm.entity.TwoFactorBackupCode;
+import aranya.crm.entity.User;
+import aranya.crm.repository.TwoFactorBackupCodeRepository;
+import aranya.crm.repository.UserRepository;
+import dev.samstevens.totp.code.*;
+import dev.samstevens.totp.secret.DefaultSecretGenerator;
+import dev.samstevens.totp.secret.SecretGenerator;
+import dev.samstevens.totp.time.SystemTimeProvider;
+import dev.samstevens.totp.time.TimeProvider;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TwoFactorService {
+
+    private static final int BACKUP_CODE_COUNT = 8;
+    private static final String BACKUP_CODE_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+    private static final String AES_ALGORITHM = "AES/GCM/NoPadding";
+    private static final int GCM_IV_LENGTH = 12;
+    private static final int GCM_TAG_BITS = 128;
+
+    private final AppProperties appProperties;
+    private final TwoFactorBackupCodeRepository backupCodeRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    private SecretGenerator secretGenerator;
+    private DefaultCodeVerifier codeVerifier;
+
+    // "userId:code" -> expiry ms — prevents OTP replay within the tolerance window
+    private final ConcurrentHashMap<String, Long> usedOtpCache = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    public void init() {
+        secretGenerator = new DefaultSecretGenerator(32);
+        TimeProvider timeProvider = new SystemTimeProvider();
+        CodeGenerator codeGenerator = new DefaultCodeGenerator(HashingAlgorithm.SHA1, 6);
+        codeVerifier = new DefaultCodeVerifier(codeGenerator, timeProvider);
+        codeVerifier.setAllowedTimePeriodDiscrepancy(1);
+    }
+
+    public TwoFactorSetupResponse generateSetup(String email) {
+        String secret = secretGenerator.generate();
+        String issuer = appProperties.getTwoFactor().getIssuer();
+        String label = URLEncoder.encode(issuer + ":" + email, StandardCharsets.UTF_8);
+        String encodedIssuer = URLEncoder.encode(issuer, StandardCharsets.UTF_8);
+        String uri = String.format(
+                "otpauth://totp/%s?secret=%s&issuer=%s&algorithm=SHA1&digits=6&period=30",
+                label, secret, encodedIssuer);
+        return TwoFactorSetupResponse.builder()
+                .secret(secret)
+                .qrCodeUri(uri)
+                .build();
+    }
+
+    @Transactional
+    public List<String> enableTwoFactor(Long userId, TwoFactorEnableRequest request) {
+        User user = loadUser(userId);
+        if (user.isTwoFactorEnabled()) {
+            throw new IllegalStateException("2FA is already enabled. Disable it first before re-configuring.");
+        }
+        if (!codeVerifier.isValidCode(request.getSecret(), request.getCode())) {
+            throw new BadCredentialsException("Invalid 2FA code");
+        }
+        user.setTwoFactorSecret(encryptSecret(request.getSecret()));
+        user.setTwoFactorEnabled(true);
+        userRepository.save(user);
+        log.info("2FA enabled for userId: {}", userId);
+        return generateAndSaveBackupCodes(user);
+    }
+
+    @Transactional
+    public void disableTwoFactor(Long userId, TwoFactorDisableRequest request) {
+        User user = loadUser(userId);
+        if (!user.isTwoFactorEnabled()) {
+            throw new IllegalStateException("2FA is not enabled");
+        }
+        if (!passwordEncoder.matches(request.getPassword(), user.getPasswordHash())) {
+            throw new BadCredentialsException("Invalid password");
+        }
+        if (!verifyCodeForUser(user, request.getCode())) {
+            throw new BadCredentialsException("Invalid 2FA code");
+        }
+        user.setTwoFactorEnabled(false);
+        user.setTwoFactorSecret(null);
+        userRepository.save(user);
+        backupCodeRepository.deleteByUserId(userId);
+        log.info("2FA disabled for userId: {}", userId);
+    }
+
+    @Transactional
+    public List<String> regenerateBackupCodes(Long userId) {
+        User user = loadUser(userId);
+        if (!user.isTwoFactorEnabled()) {
+            throw new IllegalStateException("2FA is not enabled");
+        }
+        log.info("Backup codes regenerated for userId: {}", userId);
+        return generateAndSaveBackupCodes(user);
+    }
+
+    boolean verifyCodeForUser(User user, String code) {
+        evictExpiredOtpEntries();
+        if (code == null || code.isBlank()) return false;
+
+        if (code.length() == 6 && code.chars().allMatch(Character::isDigit)) {
+            return verifyTotp(user, code);
+        }
+        return verifyAndConsumeBackupCode(user, code);
+    }
+
+    private boolean verifyTotp(User user, String code) {
+        if (user.getTwoFactorSecret() == null) return false;
+        String cacheKey = user.getId() + ":" + code;
+        if (usedOtpCache.containsKey(cacheKey)) {
+            log.warn("OTP replay attempt detected for userId: {}", user.getId());
+            return false;
+        }
+        String rawSecret = decryptSecret(user.getTwoFactorSecret());
+        if (!codeVerifier.isValidCode(rawSecret, code)) return false;
+        usedOtpCache.put(cacheKey, System.currentTimeMillis() + 90_000L);
+        return true;
+    }
+
+    @Transactional
+    boolean verifyAndConsumeBackupCode(User user, String code) {
+        String hash = hashValue(code.toUpperCase().trim());
+        Optional<TwoFactorBackupCode> found =
+                backupCodeRepository.findByUserIdAndCodeHashAndUsedFalse(user.getId(), hash);
+        if (found.isEmpty()) return false;
+        found.get().setUsed(true);
+        backupCodeRepository.save(found.get());
+        log.info("Backup code consumed for userId: {}", user.getId());
+        return true;
+    }
+
+    private List<String> generateAndSaveBackupCodes(User user) {
+        backupCodeRepository.deleteByUserId(user.getId());
+        SecureRandom random = new SecureRandom();
+        List<String> rawCodes = new ArrayList<>(BACKUP_CODE_COUNT);
+        List<TwoFactorBackupCode> entities = new ArrayList<>(BACKUP_CODE_COUNT);
+        for (int i = 0; i < BACKUP_CODE_COUNT; i++) {
+            String code = generateBackupCode(random);
+            rawCodes.add(code);
+            TwoFactorBackupCode entity = new TwoFactorBackupCode();
+            entity.setUser(user);
+            entity.setCodeHash(hashValue(code));
+            entities.add(entity);
+        }
+        backupCodeRepository.saveAll(entities);
+        return rawCodes;
+    }
+
+    private String generateBackupCode(SecureRandom random) {
+        StringBuilder sb = new StringBuilder(8);
+        for (int i = 0; i < 8; i++) {
+            sb.append(BACKUP_CODE_CHARS.charAt(random.nextInt(BACKUP_CODE_CHARS.length())));
+        }
+        return sb.toString();
+    }
+
+    String encryptSecret(String rawSecret) {
+        try {
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            new SecureRandom().nextBytes(iv);
+            Cipher cipher = Cipher.getInstance(AES_ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, getAesKey(), new GCMParameterSpec(GCM_TAG_BITS, iv));
+            byte[] ciphertext = cipher.doFinal(rawSecret.getBytes(StandardCharsets.UTF_8));
+            byte[] combined = new byte[iv.length + ciphertext.length];
+            System.arraycopy(iv, 0, combined, 0, iv.length);
+            System.arraycopy(ciphertext, 0, combined, iv.length, ciphertext.length);
+            return Base64.getEncoder().encodeToString(combined);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to encrypt TOTP secret", e);
+        }
+    }
+
+    private String decryptSecret(String encryptedSecret) {
+        try {
+            byte[] combined = Base64.getDecoder().decode(encryptedSecret);
+            byte[] iv = Arrays.copyOfRange(combined, 0, GCM_IV_LENGTH);
+            byte[] ciphertext = Arrays.copyOfRange(combined, GCM_IV_LENGTH, combined.length);
+            Cipher cipher = Cipher.getInstance(AES_ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, getAesKey(), new GCMParameterSpec(GCM_TAG_BITS, iv));
+            return new String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to decrypt TOTP secret", e);
+        }
+    }
+
+    private SecretKey getAesKey() {
+        byte[] keyBytes = Base64.getDecoder().decode(appProperties.getTwoFactor().getEncryptionKey());
+        if (keyBytes.length != 32) {
+            throw new IllegalStateException("TWO_FACTOR_ENCRYPTION_KEY must be 32 bytes (Base64-encoded)");
+        }
+        return new SecretKeySpec(keyBytes, "AES");
+    }
+
+    private String hashValue(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    private void evictExpiredOtpEntries() {
+        long now = System.currentTimeMillis();
+        usedOtpCache.entrySet().removeIf(e -> e.getValue() < now);
+    }
+
+    private User loadUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new NoSuchElementException("User not found: " + userId));
+    }
+}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,3 +1,8 @@
+app:
+  two-factor:
+    # Base64 of "AranyaCRM2FADevKeyForTesting1234" (32 bytes) — dev only, set TWO_FACTOR_ENCRYPTION_KEY in prod
+    encryption-key: ${TWO_FACTOR_ENCRYPTION_KEY:QXJhbnlhQ1JNMkZBRGV2S2V5Rm9yVGVzdGluZzEyMzQ=}
+
 spring:
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/aranya_crm}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,6 +7,10 @@ app:
     secret: ${JWT_SECRET}
     access-token-expiration: 1800000
     refresh-token-expiration: 604800000
+  two-factor:
+    issuer: AranyaCRM
+    temp-token-expiration: 300000
+    encryption-key: ${TWO_FACTOR_ENCRYPTION_KEY}
 
 spring:
   profiles:

--- a/backend/src/main/resources/db/changelog/changes/019-add-2fa-columns-to-users.yaml
+++ b/backend/src/main/resources/db/changelog/changes/019-add-2fa-columns-to-users.yaml
@@ -1,0 +1,24 @@
+databaseChangeLog:
+  - changeSet:
+      id: 019
+      author: ShiDu
+      changes:
+        - addColumn:
+            tableName: users
+            columns:
+              - column:
+                  name: two_factor_enabled
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: two_factor_secret
+                  type: VARCHAR(512)
+      rollback:
+        - dropColumn:
+            tableName: users
+            columnName: two_factor_enabled
+        - dropColumn:
+            tableName: users
+            columnName: two_factor_secret

--- a/backend/src/main/resources/db/changelog/changes/020-create-two-factor-backup-codes-table.yaml
+++ b/backend/src/main/resources/db/changelog/changes/020-create-two-factor-backup-codes-table.yaml
@@ -1,0 +1,47 @@
+databaseChangeLog:
+  - changeSet:
+      id: 020
+      author: ShiDu
+      changes:
+        - createTable:
+            tableName: two_factor_backup_code
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_backup_code_user
+                    references: users(id)
+              - column:
+                  name: code_hash
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: used
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+        - createIndex:
+            tableName: two_factor_backup_code
+            indexName: idx_backup_code_user_id
+            columns:
+              - column:
+                  name: user_id
+      rollback:
+        - dropTable:
+            tableName: two_factor_backup_code


### PR DESCRIPTION
  ## Summary

  - Add TOTP-based 2FA (Google Authenticator / Authy compatible) to the login flow
  - Introduce a two-step login: password → temp token → TOTP verify → full tokens
  - AES-256-GCM encrypted storage of TOTP secrets; 8 one-time backup codes per user
  - Fix security gap: JwtAuthFilter now rejects all non-ACCESS tokens (previously only rejected REFRESH tokens, allowing TWO_FACTOR temp
  tokens to access protected endpoints)

  ## New Endpoints

  | Method | Path | Auth | Description |
  |--------|------|------|-------------|
  | POST | `/api/v1/auth/2fa/verify` | tempToken (in body) | Step 2 of 2FA login |
  | GET | `/api/v1/auth/2fa/setup` | Bearer | Generate TOTP secret + QR URI |
  | POST | `/api/v1/auth/2fa/enable` | Bearer | Confirm setup and enable 2FA, returns backup codes |
  | POST | `/api/v1/auth/2fa/disable` | Bearer | Disable 2FA (requires password + code) |
  | POST | `/api/v1/auth/2fa/backup-codes` | Bearer | Regenerate backup codes |

  ## Database Changes

  - `users`: add `two_factor_enabled` (BOOLEAN), `two_factor_secret` (VARCHAR 512, AES-encrypted)
  - new table `two_factor_backup_code`: stores SHA-256 hashed one-time backup codes

  ## Test Plan

  - [ ] Normal login (2FA disabled) still returns tokens directly
  - [ ] Setup → enable 2FA → login returns `requiresTwoFactor: true` + `tempToken`
  - [ ] Verify with valid TOTP code → returns full tokens
  - [ ] Verify with backup code → succeeds, code marked used
  - [ ] Same TOTP code submitted twice → second attempt rejected (replay prevention)
  - [ ] tempToken used directly on protected endpoint → 401
  - [ ] Expired tempToken (>5 min) → 401