### PR TITLE
feat(auth): drive UI access from backend capabilities

### DIFF
--- a/backend/src/main/java/aranya/crm/controller/UiManifestController.java
+++ b/backend/src/main/java/aranya/crm/controller/UiManifestController.java
@@ -1,0 +1,26 @@
+package aranya.crm.controller;
+
+import aranya.crm.service.UiManifestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/ui")
+@RequiredArgsConstructor
+public class UiManifestController {
+
+    private final UiManifestService uiManifestService;
+
+    @GetMapping("/manifest")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Map<String, Object>> getManifest(Authentication authentication) {
+        return ResponseEntity.ok(uiManifestService.buildManifest(authentication));
+    }
+}

--- a/backend/src/main/java/aranya/crm/dto/MeResponse.java
+++ b/backend/src/main/java/aranya/crm/dto/MeResponse.java
@@ -3,13 +3,10 @@ package aranya.crm.dto;
 import lombok.Builder;
 import lombok.Data;
 
-import java.util.List;
-
 @Data
 @Builder
 public class MeResponse {
     private Long id;
     private String email;
     private String fullName;
-    private List<String> roles;
 }

--- a/backend/src/main/java/aranya/crm/service/UiManifestService.java
+++ b/backend/src/main/java/aranya/crm/service/UiManifestService.java
@@ -1,0 +1,69 @@
+package aranya.crm.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class UiManifestService {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public Map<String, Object> buildManifest(Authentication authentication) {
+        List<String> roleNames = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .filter(authority -> authority.startsWith("ROLE_"))
+                .map(authority -> authority.substring("ROLE_".length()))
+                .toList();
+
+        Map<String, List<String>> capabilities = new LinkedHashMap<>();
+        capabilities.put("routes", new ArrayList<>());
+        capabilities.put("features", new ArrayList<>());
+        capabilities.put("widgets", new ArrayList<>());
+
+        if (roleNames.isEmpty()) {
+            return mapOf(capabilities);
+        }
+
+        String placeholders = String.join(",", roleNames.stream().map(_ignored -> "?").toList());
+        String sql = """
+                SELECT DISTINCT p.code, p.type
+                FROM permission p
+                JOIN role_permission rp ON rp.permission_id = p.id
+                JOIN role r ON r.id = rp.role_id
+                WHERE r.name IN (%s)
+                ORDER BY p.type, p.code
+                """.formatted(placeholders);
+
+        jdbcTemplate.query(sql, rs -> {
+            String type = rs.getString("type");
+            String code = rs.getString("code");
+            switch (type) {
+                case "ROUTE" -> capabilities.get("routes").add(code);
+                case "FEATURE" -> capabilities.get("features").add(code);
+                case "WIDGET" -> capabilities.get("widgets").add(code);
+                default -> {
+                    // Ignore unknown capability types so old clients are not broken by future types.
+                }
+            }
+        }, roleNames.toArray());
+
+        return mapOf(capabilities);
+    }
+
+    private Map<String, Object> mapOf(Map<String, List<String>> capabilities) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("routes", capabilities.get("routes"));
+        response.put("features", capabilities.get("features"));
+        response.put("widgets", capabilities.get("widgets"));
+        return response;
+    }
+}

--- a/backend/src/main/java/aranya/crm/service/UserService.java
+++ b/backend/src/main/java/aranya/crm/service/UserService.java
@@ -14,7 +14,6 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,21 +47,15 @@ public class UserService {
     }
 
     /**
-     * 当前已认证用户的 profile + roles。
-     * 角色直接从 SecurityContext 的 authorities 解出（去掉 ROLE_ 前缀），
-     * 避免再走一次 DB 查询。
+     * 当前已认证用户的基础 profile。
+     * UI 渲染权限由 /ui/manifest 单独返回，/me 不暴露角色信息。
      */
     @Transactional(readOnly = true)
     public MeResponse getCurrentUser(UserPrincipal principal) {
-        List<String> roles = principal.getAuthorities().stream()
-                .map(GrantedAuthority::getAuthority)
-                .map(a -> a.startsWith("ROLE_") ? a.substring("ROLE_".length()) : a)
-                .toList();
         return MeResponse.builder()
                 .id(principal.getId())
                 .email(principal.getEmail())
                 .fullName(principal.getFullName())
-                .roles(roles)
                 .build();
     }
 

--- a/backend/src/main/resources/db/changelog/changes/024-create-permission-and-role-permission.yaml
+++ b/backend/src/main/resources/db/changelog/changes/024-create-permission-and-role-permission.yaml
@@ -1,0 +1,241 @@
+databaseChangeLog:
+  - changeSet:
+      id: 024-1-create-permission-table
+      author: ShiDu
+      comment: "Create permission table for fine-grained route, feature, and widget capabilities"
+      changes:
+        - createTable:
+            tableName: permission
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: code
+                  type: VARCHAR(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: type
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: description
+                  type: VARCHAR(255)
+        - addUniqueConstraint:
+            tableName: permission
+            columnNames: code, type
+            constraintName: uq_permission_code_type
+        - createIndex:
+            indexName: idx_permission_type
+            tableName: permission
+            columns:
+              - column:
+                  name: type
+
+  - changeSet:
+      id: 024-2-create-role-permission-table
+      author: ShiDu
+      comment: "Map roles to fine-grained capabilities"
+      changes:
+        - createTable:
+            tableName: role_permission
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: role_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_role_permission_role
+                    references: role(id)
+              - column:
+                  name: permission_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_role_permission_permission
+                    references: permission(id)
+        - addUniqueConstraint:
+            tableName: role_permission
+            columnNames: role_id, permission_id
+            constraintName: uq_role_permission_role_id_permission_id
+        - createIndex:
+            indexName: idx_role_permission_role_id
+            tableName: role_permission
+            columns:
+              - column:
+                  name: role_id
+
+  - changeSet:
+      id: 024-3-seed-permissions
+      author: ShiDu
+      comment: "Seed route, feature, and widget capability codes"
+      changes:
+        - sql:
+            sql: >
+              INSERT INTO permission (code, type, description) VALUES
+                ('dashboard', 'ROUTE', 'Route: dashboard'),
+                ('clients.list', 'ROUTE', 'Route: client list'),
+                ('clients.create', 'ROUTE', 'Route: create client'),
+                ('clients.detail', 'ROUTE', 'Route: client detail'),
+                ('clients.edit', 'ROUTE', 'Route: edit client'),
+                ('cases.list', 'ROUTE', 'Route: case list'),
+                ('cases.create', 'ROUTE', 'Route: create case'),
+                ('cases.detail', 'ROUTE', 'Route: case detail'),
+                ('reports.list', 'ROUTE', 'Route: report list'),
+                ('reports.create', 'ROUTE', 'Route: create report'),
+                ('users.list', 'ROUTE', 'Route: user management'),
+                ('dashboard.view', 'FEATURE', 'View dashboard'),
+                ('clients.search', 'FEATURE', 'Search clients'),
+                ('clients.view.basic', 'FEATURE', 'View restricted client profile'),
+                ('clients.view.full', 'FEATURE', 'View full client profile'),
+                ('clients.create', 'FEATURE', 'Create client profile'),
+                ('clients.update', 'FEATURE', 'Update client profile'),
+                ('clients.delete', 'FEATURE', 'Delete client profile'),
+                ('clients.contacts.link', 'FEATURE', 'Link related contacts'),
+                ('cases.view', 'FEATURE', 'View cases'),
+                ('cases.notes.create', 'FEATURE', 'Add case notes'),
+                ('cases.create', 'FEATURE', 'Create cases'),
+                ('cases.status.update', 'FEATURE', 'Update case status'),
+                ('cases.assignVolunteer', 'FEATURE', 'Assign volunteers to cases'),
+                ('cases.close', 'FEATURE', 'Close cases'),
+                ('cases.documents.uploadEdit', 'FEATURE', 'Upload or edit case documents'),
+                ('cases.documents.delete', 'FEATURE', 'Delete case documents'),
+                ('cases.audit', 'FEATURE', 'Audit case records'),
+                ('reports.create', 'FEATURE', 'Create reports'),
+                ('reports.view.own', 'FEATURE', 'View own reports'),
+                ('reports.view.all', 'FEATURE', 'View all reports'),
+                ('reports.update', 'FEATURE', 'Update reports'),
+                ('reports.delete', 'FEATURE', 'Delete reports'),
+                ('reports.approveArchive', 'FEATURE', 'Approve or archive reports'),
+                ('alerts.receiveUrgent', 'FEATURE', 'Receive urgent alerts'),
+                ('users.invite', 'FEATURE', 'Invite users'),
+                ('users.assignRoles', 'FEATURE', 'Assign user access groups'),
+                ('dashboard.myReports', 'WIDGET', 'Dashboard widget: my reports'),
+                ('dashboard.pendingTasks', 'WIDGET', 'Dashboard widget: pending tasks'),
+                ('dashboard.recentReports', 'WIDGET', 'Dashboard widget: recent reports'),
+                ('dashboard.totalClients', 'WIDGET', 'Dashboard widget: total clients'),
+                ('dashboard.activeCases', 'WIDGET', 'Dashboard widget: active cases'),
+                ('dashboard.pendingVisits', 'WIDGET', 'Dashboard widget: pending visits'),
+                ('dashboard.urgentCases', 'WIDGET', 'Dashboard widget: urgent cases'),
+                ('dashboard.upcomingAppointments', 'WIDGET', 'Dashboard widget: upcoming appointments')
+              ON CONFLICT (code, type) DO NOTHING;
+
+  - changeSet:
+      id: 024-4-seed-role-permissions
+      author: ShiDu
+      comment: "Seed role-to-capability mappings"
+      changes:
+        - sql:
+            sql: >
+              INSERT INTO role_permission (role_id, permission_id)
+              SELECT r.id, p.id
+              FROM role r
+              JOIN permission p ON
+                (r.name = 'VOLUNTEER' AND p.code IN (
+                  'dashboard',
+                  'clients.list',
+                  'clients.detail',
+                  'reports.list',
+                  'reports.create',
+                  'dashboard.view',
+                  'clients.search',
+                  'clients.view.basic',
+                  'reports.create',
+                  'reports.view.own',
+                  'dashboard.myReports',
+                  'dashboard.pendingTasks',
+                  'dashboard.recentReports'
+                ))
+                OR (r.name = 'SOCIAL_WORKER' AND p.code IN (
+                  'dashboard',
+                  'clients.list',
+                  'clients.detail',
+                  'clients.edit',
+                  'cases.list',
+                  'cases.create',
+                  'cases.detail',
+                  'reports.list',
+                  'reports.create',
+                  'dashboard.view',
+                  'clients.search',
+                  'clients.view.full',
+                  'clients.update',
+                  'clients.contacts.link',
+                  'cases.view',
+                  'cases.notes.create',
+                  'cases.create',
+                  'cases.status.update',
+                  'cases.assignVolunteer',
+                  'cases.documents.uploadEdit',
+                  'reports.create',
+                  'reports.view.all',
+                  'reports.update',
+                  'reports.delete',
+                  'alerts.receiveUrgent',
+                  'dashboard.totalClients',
+                  'dashboard.activeCases',
+                  'dashboard.pendingVisits',
+                  'dashboard.myReports',
+                  'dashboard.pendingTasks',
+                  'dashboard.recentReports',
+                  'dashboard.upcomingAppointments'
+                ))
+                OR (r.name = 'MANAGER' AND p.code IN (
+                  'dashboard',
+                  'clients.list',
+                  'clients.create',
+                  'clients.detail',
+                  'clients.edit',
+                  'cases.list',
+                  'cases.create',
+                  'cases.detail',
+                  'reports.list',
+                  'reports.create',
+                  'users.list',
+                  'dashboard.view',
+                  'clients.search',
+                  'clients.view.full',
+                  'clients.create',
+                  'clients.update',
+                  'clients.delete',
+                  'clients.contacts.link',
+                  'cases.view',
+                  'cases.notes.create',
+                  'cases.create',
+                  'cases.status.update',
+                  'cases.assignVolunteer',
+                  'cases.close',
+                  'cases.documents.uploadEdit',
+                  'cases.documents.delete',
+                  'cases.audit',
+                  'reports.create',
+                  'reports.view.all',
+                  'reports.update',
+                  'reports.delete',
+                  'reports.approveArchive',
+                  'alerts.receiveUrgent',
+                  'users.invite',
+                  'users.assignRoles',
+                  'dashboard.totalClients',
+                  'dashboard.activeCases',
+                  'dashboard.pendingVisits',
+                  'dashboard.urgentCases',
+                  'dashboard.myReports',
+                  'dashboard.pendingTasks',
+                  'dashboard.recentReports',
+                  'dashboard.upcomingAppointments'
+                ))
+              ON CONFLICT (role_id, permission_id) DO NOTHING;

--- a/backend/src/test/java/aranya/crm/controller/UiManifestControllerTest.java
+++ b/backend/src/test/java/aranya/crm/controller/UiManifestControllerTest.java
@@ -1,0 +1,91 @@
+package aranya.crm.controller;
+
+import aranya.crm.security.util.JwtUtil;
+import aranya.crm.service.CustomUserDetailsService;
+import aranya.crm.service.UiManifestService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Map;
+
+@WebMvcTest(controllers = UiManifestController.class)
+@Import(UiManifestControllerTest.TestSecurityConfig.class)
+class UiManifestControllerTest {
+
+    @TestConfiguration
+    @EnableWebSecurity
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(AbstractHttpConfigurer::disable)
+                    .authorizeHttpRequests(a -> a.anyRequest().permitAll());
+            return http.build();
+        }
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    @MockBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockBean
+    private UiManifestService uiManifestService;
+
+    @Test
+    @DisplayName("Manifest returns capability ids without role or layout fields")
+    @WithMockUser(username = "volunteer@test.com", roles = "VOLUNTEER")
+    void manifest_returnsCapabilityIds_withoutRoleOrLayoutFields() throws Exception {
+        when(uiManifestService.buildManifest(any())).thenReturn(Map.of(
+                "routes", List.of("dashboard", "reports.list", "reports.create"),
+                "features", List.of("dashboard.view", "reports.create", "reports.view.own"),
+                "widgets", List.of("dashboard.myReports")
+        ));
+
+        mockMvc.perform(get("/api/v1/ui/manifest"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.routes[0]").value("dashboard"))
+                .andExpect(jsonPath("$.features[1]").value("reports.create"))
+                .andExpect(jsonPath("$.widgets[0]").value("dashboard.myReports"))
+                .andExpect(jsonPath("$.navigation").doesNotExist())
+                .andExpect(jsonPath("$.pages").doesNotExist())
+                .andExpect(jsonPath("$.sharedRegistry").doesNotExist())
+                .andExpect(jsonPath("$.session").doesNotExist())
+                .andExpect(jsonPath("$.roles").doesNotExist())
+                .andExpect(content().string(not(containsString("VOLUNTEER"))));
+    }
+
+    @Test
+    @DisplayName("Anonymous manifest request returns 403")
+    void manifest_returns403_forAnonymous() throws Exception {
+        mockMvc.perform(get("/api/v1/ui/manifest"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/backend/src/test/java/aranya/crm/controller/UserControllerTest.java
+++ b/backend/src/test/java/aranya/crm/controller/UserControllerTest.java
@@ -123,51 +123,48 @@ class UserControllerTest {
     /* ── /me endpoint：方法级 isAuthenticated() 显式覆盖类级 hasRole('MANAGER') ── */
 
     @Test
-    @DisplayName("Volunteer 调用 GET /api/v1/users/me 返回 200 + 自己的 roles")
+    @DisplayName("Volunteer 调用 GET /api/v1/users/me 返回 200 且不返回 roles")
     @WithMockUser(roles = "VOLUNTEER")
     void me_returns200_forVolunteer() throws Exception {
         when(userService.getCurrentUser(any())).thenReturn(
                 MeResponse.builder()
                         .id(2L).email("v@x.com").fullName("V")
-                        .roles(List.of("VOLUNTEER"))
                         .build()
         );
 
         mockMvc.perform(get("/api/v1/users/me"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.roles[0]").value("VOLUNTEER"));
+                .andExpect(jsonPath("$.roles").doesNotExist());
     }
 
     @Test
-    @DisplayName("Social Worker 调用 GET /api/v1/users/me 返回 200 + 自己的 roles")
+    @DisplayName("Social Worker 调用 GET /api/v1/users/me 返回 200 且不返回 roles")
     @WithMockUser(roles = "SOCIAL_WORKER")
     void me_returns200_forSocialWorker() throws Exception {
         when(userService.getCurrentUser(any())).thenReturn(
                 MeResponse.builder()
                         .id(3L).email("sw@x.com").fullName("SW")
-                        .roles(List.of("SOCIAL_WORKER"))
                         .build()
         );
 
         mockMvc.perform(get("/api/v1/users/me"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.roles[0]").value("SOCIAL_WORKER"));
+                .andExpect(jsonPath("$.roles").doesNotExist());
     }
 
     @Test
-    @DisplayName("Manager 调用 GET /api/v1/users/me 返回 200 + 自己的 roles")
+    @DisplayName("Manager 调用 GET /api/v1/users/me 返回 200 且不返回 roles")
     @WithMockUser(roles = "MANAGER")
     void me_returns200_forManager() throws Exception {
         when(userService.getCurrentUser(any())).thenReturn(
                 MeResponse.builder()
                         .id(1L).email("admin@x.com").fullName("Admin")
-                        .roles(List.of("MANAGER"))
                         .build()
         );
 
         mockMvc.perform(get("/api/v1/users/me"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.roles[0]").value("MANAGER"));
+                .andExpect(jsonPath("$.roles").doesNotExist());
     }
 
     @Test

--- a/docs/System Design/sitemap.md
+++ b/docs/System Design/sitemap.md
@@ -1,0 +1,308 @@
+# Aranya CRM Capability Sitemap
+
+## Boundary
+
+The frontend owns components, layout, labels, table columns, icons, and interaction design.
+
+The backend owns authentication, authorization decisions, route access, action access, and dynamic business data.
+
+The backend must not send component definitions, static labels, layout instructions, table columns, field labels, colors, or role names to the frontend. It only sends capability ids and dynamic data.
+
+## Capability Endpoint
+
+```http
+GET /api/v1/ui/manifest
+Authorization: Bearer <accessToken>
+```
+
+Response:
+
+```json
+{
+  "routes": [
+    "dashboard",
+    "reports.list",
+    "reports.create"
+  ],
+  "features": [
+    "dashboard.view",
+    "reports.create",
+    "reports.view.own"
+  ],
+  "widgets": [
+    "dashboard.myReports",
+    "dashboard.pendingTasks"
+  ]
+}
+```
+
+The response must not contain:
+
+- role names
+- user role arrays
+- navigation labels
+- component props
+- table columns
+- form field labels
+- layout metadata
+
+## Frontend Usage
+
+The frontend keeps fixed local registries:
+
+- route id to route path/component
+- sidebar item definitions
+- dashboard widget definitions
+- table column definitions
+- page layouts
+- button labels and icons
+
+The frontend only checks capability ids:
+
+```ts
+canRoute('reports.list')
+canFeature('reports.create')
+canWidget('dashboard.myReports')
+```
+
+Example local sidebar registry:
+
+```ts
+const NAV_ITEMS = [
+  { routeId: 'dashboard', path: '/dashboard', labelZh: '工作台', labelEn: 'Dashboard' },
+  { routeId: 'clients.list', path: '/clients', labelZh: '僧人档案', labelEn: 'Clients' },
+  { routeId: 'cases.list', path: '/cases', labelZh: '个案管理', labelEn: 'Cases' },
+  { routeId: 'reports.list', path: '/reports', labelZh: '探访报告', labelEn: 'Reports' },
+  { routeId: 'users.list', path: '/users', labelZh: '用户管理', labelEn: 'Users' }
+]
+```
+
+If `canRoute(item.routeId)` is false, the frontend hides that sidebar item and blocks direct route access.
+
+## Route Capabilities
+
+| id | frontend path |
+|---|---|
+| dashboard | /dashboard |
+| clients.list | /clients |
+| clients.create | /clients/new |
+| clients.detail | /clients/:id |
+| clients.edit | /clients/:id/edit |
+| cases.list | /cases |
+| cases.create | /cases/new |
+| cases.detail | /cases/:id |
+| reports.list | /reports |
+| reports.create | /reports/new |
+| users.list | /users |
+
+## Feature Capabilities
+
+### Dashboard
+
+| id | meaning |
+|---|---|
+| dashboard.view | May access dashboard |
+
+### Client Profiles
+
+| id | meaning |
+|---|---|
+| clients.search | May search client profiles |
+| clients.view.basic | May view restricted client profile |
+| clients.view.full | May view full client profile |
+| clients.create | May create client profile |
+| clients.update | May edit client profile |
+| clients.delete | May delete client profile |
+| clients.contacts.link | May link related contacts |
+
+### Cases
+
+| id | meaning |
+|---|---|
+| cases.view | May view cases |
+| cases.notes.create | May add notes to cases |
+| cases.create | May create cases |
+| cases.status.update | May update case status |
+| cases.assignVolunteer | May assign volunteers |
+| cases.close | May close cases |
+| cases.documents.uploadEdit | May upload/edit documents |
+| cases.documents.delete | May delete documents |
+| cases.audit | May audit case records |
+
+### Reports
+
+| id | meaning |
+|---|---|
+| reports.create | May create reports |
+| reports.view.own | May view own reports |
+| reports.view.all | May view all reports |
+| reports.update | May edit reports |
+| reports.delete | May delete reports |
+| reports.approveArchive | May approve/archive reports |
+
+### Users
+
+| id | meaning |
+|---|---|
+| users.invite | May invite users |
+| users.assignRoles | May assign access groups |
+
+### Alerts
+
+| id | meaning |
+|---|---|
+| alerts.receiveUrgent | May receive urgent alerts |
+
+## Dashboard Widget Capabilities
+
+| id | meaning |
+|---|---|
+| dashboard.myReports | Show current user's report widget |
+| dashboard.pendingTasks | Show current user's pending tasks widget |
+| dashboard.recentReports | Show recent reports widget |
+| dashboard.totalClients | Show total clients stat |
+| dashboard.activeCases | Show active cases stat |
+| dashboard.pendingVisits | Show pending visits stat |
+| dashboard.urgentCases | Show urgent cases stat |
+| dashboard.upcomingAppointments | Show upcoming appointments widget |
+
+## Current Role-to-Capability Mapping
+
+Role names are backend/database details. They are listed here only for system design and seeding.
+
+### Volunteer
+
+Routes:
+
+- dashboard
+- clients.list
+- clients.detail
+- reports.list
+- reports.create
+
+Features:
+
+- dashboard.view
+- clients.search
+- clients.view.basic
+- reports.create
+- reports.view.own
+
+Widgets:
+
+- dashboard.myReports
+- dashboard.pendingTasks
+- dashboard.recentReports
+
+### Social Worker
+
+Routes:
+
+- dashboard
+- clients.list
+- clients.detail
+- clients.edit
+- cases.list
+- cases.create
+- cases.detail
+- reports.list
+- reports.create
+
+Features:
+
+- dashboard.view
+- clients.search
+- clients.view.full
+- clients.update
+- clients.contacts.link
+- cases.view
+- cases.notes.create
+- cases.create
+- cases.status.update
+- cases.assignVolunteer
+- cases.documents.uploadEdit
+- reports.create
+- reports.view.all
+- reports.update
+- reports.delete
+- alerts.receiveUrgent
+
+Widgets:
+
+- dashboard.totalClients
+- dashboard.activeCases
+- dashboard.pendingVisits
+- dashboard.myReports
+- dashboard.pendingTasks
+- dashboard.recentReports
+- dashboard.upcomingAppointments
+
+### Manager
+
+Routes:
+
+- dashboard
+- clients.list
+- clients.create
+- clients.detail
+- clients.edit
+- cases.list
+- cases.create
+- cases.detail
+- reports.list
+- reports.create
+- users.list
+
+Features:
+
+- dashboard.view
+- clients.search
+- clients.view.full
+- clients.create
+- clients.update
+- clients.delete
+- clients.contacts.link
+- cases.view
+- cases.notes.create
+- cases.create
+- cases.status.update
+- cases.assignVolunteer
+- cases.close
+- cases.documents.uploadEdit
+- cases.documents.delete
+- cases.audit
+- reports.create
+- reports.view.all
+- reports.update
+- reports.delete
+- reports.approveArchive
+- alerts.receiveUrgent
+- users.invite
+- users.assignRoles
+
+Widgets:
+
+- dashboard.totalClients
+- dashboard.activeCases
+- dashboard.pendingVisits
+- dashboard.urgentCases
+- dashboard.myReports
+- dashboard.pendingTasks
+- dashboard.recentReports
+- dashboard.upcomingAppointments
+
+## Page Data APIs
+
+Capabilities do not replace page data APIs. Pages still request dynamic data from their own endpoints.
+
+Examples:
+
+```http
+GET /api/v1/dashboard
+GET /api/v1/reports?scope=mine&page=1
+GET /api/v1/clients?search=...
+POST /api/v1/reports
+PATCH /api/v1/cases/{caseId}/status
+```
+
+The backend must enforce authorization on these business APIs independently. The capability endpoint is for rendering and route gating, not a security boundary.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,21 +13,16 @@ import { DashboardPage } from './pages/dashboard/DashboardPage'
 import { LoginPage } from './pages/login/LoginPage'
 import { ReportFormPage } from './pages/reports/ReportFormPage'
 import { ReportListPage } from './pages/reports/ReportListPage'
-import type { UserRole } from './services/auth'
 
-interface RoleProtectedRouteProps {
-  /**
-   * If provided, only users whose role is in this list can enter the route.
-   * Omit to require authentication only.
-   */
-  allow?: UserRole[]
+interface ManifestProtectedRouteProps {
+  routeId: string
   children: ReactNode
 }
 
-function RoleProtectedRoute({ allow, children }: RoleProtectedRouteProps) {
-  const { loading, authenticated, hasAnyRole } = useAuth()
+function ManifestProtectedRoute({ routeId, children }: ManifestProtectedRouteProps) {
+  const { loading, authenticated, canRoute } = useAuth()
 
-  // 初始 /me 还没回来 — 显示全屏 Spin，避免闪一下登录页再跳回。
+  // 初始 profile + manifest 还没回来 — 显示全屏 Spin，避免闪一下登录页再跳回。
   if (loading) {
     return (
       <div
@@ -47,16 +42,24 @@ function RoleProtectedRoute({ allow, children }: RoleProtectedRouteProps) {
     return <Navigate to="/login" replace />
   }
 
-  if (allow && allow.length > 0 && !hasAnyRole(...allow)) {
-    // 角色不匹配 — 退到 Dashboard（所有角色都能进）。
+  if (!canRoute(routeId)) {
+    // 当前 capability 清单没有返回这个 route — 退到 Dashboard。
     return <Navigate to="/dashboard" replace />
   }
 
   return <AppLayout>{children}</AppLayout>
 }
 
-const ALL_AUTHED: UserRole[] = ['VOLUNTEER', 'SOCIAL_WORKER', 'MANAGER']
-const SW_OR_MANAGER: UserRole[] = ['SOCIAL_WORKER', 'MANAGER']
+function UsersPlaceholderPage() {
+  return (
+    <>
+      <h2 className="page-title">用户管理</h2>
+      <div className="page-subtitle">User Management</div>
+      <div className="desc-zh">用户管理页面将在后续步骤实现。</div>
+      <div className="desc-en">This page will be implemented in a later step.</div>
+    </>
+  )
+}
 
 function App() {
   return (
@@ -64,91 +67,99 @@ function App() {
       <Route path="/" element={<Navigate to="/dashboard" replace />} />
       <Route path="/login" element={<LoginPage />} />
 
-      {/* Dashboard — 所有登录用户 */}
+      {/* Dashboard */}
       <Route
         path="/dashboard"
         element={
-          <RoleProtectedRoute allow={ALL_AUTHED}>
+          <ManifestProtectedRoute routeId="dashboard">
             <DashboardPage />
-          </RoleProtectedRoute>
+          </ManifestProtectedRoute>
         }
       />
 
-      {/* Clients — 列表 / 详情：所有角色（Volunteer 看基本视图）；新建 / 编辑：SW + Manager */}
+      {/* Clients */}
       <Route
         path="/clients"
         element={
-          <RoleProtectedRoute allow={ALL_AUTHED}>
+          <ManifestProtectedRoute routeId="clients.list">
             <ClientListPage />
-          </RoleProtectedRoute>
+          </ManifestProtectedRoute>
         }
       />
       <Route
         path="/clients/new"
         element={
-          <RoleProtectedRoute allow={SW_OR_MANAGER}>
+          <ManifestProtectedRoute routeId="clients.create">
             <ClientFormPage />
-          </RoleProtectedRoute>
+          </ManifestProtectedRoute>
         }
       />
       <Route
         path="/clients/:id"
         element={
-          <RoleProtectedRoute allow={ALL_AUTHED}>
+          <ManifestProtectedRoute routeId="clients.detail">
             <ClientDetailPage />
-          </RoleProtectedRoute>
+          </ManifestProtectedRoute>
         }
       />
       <Route
         path="/clients/:id/edit"
         element={
-          <RoleProtectedRoute allow={SW_OR_MANAGER}>
+          <ManifestProtectedRoute routeId="clients.edit">
             <ClientFormPage />
-          </RoleProtectedRoute>
+          </ManifestProtectedRoute>
         }
       />
 
-      {/* Cases — SW + Manager only（Volunteer 在 sidebar 看不到，直接访问被重定向） */}
+      {/* Cases */}
       <Route
         path="/cases"
         element={
-          <RoleProtectedRoute allow={SW_OR_MANAGER}>
+          <ManifestProtectedRoute routeId="cases.list">
             <CaseListPage />
-          </RoleProtectedRoute>
+          </ManifestProtectedRoute>
         }
       />
       <Route
         path="/cases/new"
         element={
-          <RoleProtectedRoute allow={SW_OR_MANAGER}>
+          <ManifestProtectedRoute routeId="cases.create">
             <CaseFormPage />
-          </RoleProtectedRoute>
+          </ManifestProtectedRoute>
         }
       />
       <Route
         path="/cases/:id"
         element={
-          <RoleProtectedRoute allow={SW_OR_MANAGER}>
+          <ManifestProtectedRoute routeId="cases.detail">
             <CaseDetailPage />
-          </RoleProtectedRoute>
+          </ManifestProtectedRoute>
         }
       />
 
-      {/* Reports — 所有角色 */}
+      {/* Reports */}
       <Route
         path="/reports"
         element={
-          <RoleProtectedRoute allow={ALL_AUTHED}>
+          <ManifestProtectedRoute routeId="reports.list">
             <ReportListPage />
-          </RoleProtectedRoute>
+          </ManifestProtectedRoute>
         }
       />
       <Route
         path="/reports/new"
         element={
-          <RoleProtectedRoute allow={ALL_AUTHED}>
+          <ManifestProtectedRoute routeId="reports.create">
             <ReportFormPage />
-          </RoleProtectedRoute>
+          </ManifestProtectedRoute>
+        }
+      />
+      <Route
+        path="/users"
+        element={
+          <ManifestProtectedRoute routeId="users.list">
+            <UsersPlaceholderPage />
+          </ManifestProtectedRoute>
         }
       />
     </Routes>

--- a/frontend/src/components/layout/AppLayout.css
+++ b/frontend/src/components/layout/AppLayout.css
@@ -192,33 +192,6 @@
   color: var(--text-normal);
 }
 
-.topbar-role-badge {
-  display: inline-block;
-  padding: 2px 10px;
-  border-radius: 4px;
-  font-size: 11px;
-  font-weight: 600;
-  line-height: 1.4;
-}
-
-.role-social_worker {
-  background: #e8e8e8;
-  color: #333333;
-  border: 1px solid #cccccc;
-}
-
-.role-volunteer {
-  background: #dbeafe;
-  color: #1e40af;
-  border: 1px solid #bfdbfe;
-}
-
-.role-manager {
-  background: #ede9fe;
-  color: #5b21b6;
-  border: 1px solid #ddd6fe;
-}
-
 .logout-btn {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,7 +1,6 @@
 import { type ReactNode } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '../../contexts/AuthContext'
-import type { UserRole } from '../../services/auth'
 import './AppLayout.css'
 
 /* ── SVG Icons ── */
@@ -73,62 +72,64 @@ function LogoutIcon() {
 /* ── Navigation definition ── */
 
 interface NavItem {
+  id: string
+  routeId: string
   path: string
   zhLabel: string
   enLabel: string
   icon: ReactNode
-  /** Roles allowed to see this nav item. Omit to allow everyone. */
-  roles?: UserRole[]
+}
+
+const ICONS: Record<string, ReactNode> = {
+  LayoutDashboard: <DashboardIcon />,
+  Users: <ClientsIcon />,
+  FolderOpen: <CasesIcon />,
+  ClipboardList: <ReportsIcon />,
+  Shield: <UsersIcon />,
 }
 
 const NAV_ITEMS: NavItem[] = [
   {
+    id: 'dashboard',
+    routeId: 'dashboard',
     path: '/dashboard',
     zhLabel: '工作台',
     enLabel: 'Dashboard',
-    icon: <DashboardIcon />,
+    icon: ICONS.LayoutDashboard,
   },
   {
+    id: 'clients',
+    routeId: 'clients.list',
     path: '/clients',
     zhLabel: '僧人档案',
     enLabel: 'Clients',
-    icon: <ClientsIcon />,
+    icon: ICONS.Users,
   },
   {
+    id: 'cases',
+    routeId: 'cases.list',
     path: '/cases',
     zhLabel: '个案管理',
     enLabel: 'Cases',
-    icon: <CasesIcon />,
-    roles: ['SOCIAL_WORKER', 'MANAGER'],
+    icon: ICONS.FolderOpen,
   },
   {
+    id: 'reports',
+    routeId: 'reports.list',
     path: '/reports',
     zhLabel: '探访报告',
     enLabel: 'Reports',
-    icon: <ReportsIcon />,
+    icon: ICONS.ClipboardList,
   },
   {
+    id: 'users',
+    routeId: 'users.list',
     path: '/users',
     zhLabel: '用户管理',
     enLabel: 'Users',
-    icon: <UsersIcon />,
-    roles: ['MANAGER'],
+    icon: ICONS.Shield,
   },
 ]
-
-/* ── Role badge helpers ── */
-
-const ROLE_BADGE_LABEL: Record<UserRole, string> = {
-  VOLUNTEER: 'Volunteer',
-  SOCIAL_WORKER: 'Social Worker',
-  MANAGER: 'Manager',
-}
-
-const ROLE_BADGE_CLASS: Record<UserRole, string> = {
-  VOLUNTEER: 'role-volunteer',
-  SOCIAL_WORKER: 'role-social_worker',
-  MANAGER: 'role-manager',
-}
 
 /* ── Layout Component ── */
 
@@ -137,13 +138,11 @@ interface AppLayoutProps {
 }
 
 export function AppLayout({ children }: AppLayoutProps) {
-  const { user, logout, primaryRole, hasAnyRole } = useAuth()
+  const { user, canRoute, logout } = useAuth()
   const location = useLocation()
   const navigate = useNavigate()
 
-  const visibleItems = NAV_ITEMS.filter(
-    (item) => !item.roles || hasAnyRole(...item.roles),
-  )
+  const visibleItems = NAV_ITEMS.filter((item) => canRoute(item.routeId))
 
   function handleNavClick(item: NavItem) {
     navigate(item.path)
@@ -196,13 +195,6 @@ export function AppLayout({ children }: AppLayoutProps) {
               <span className="topbar-user-name">
                 {user?.fullName ?? 'User'}
               </span>
-              {primaryRole ? (
-                <span
-                  className={`topbar-role-badge ${ROLE_BADGE_CLASS[primaryRole]}`}
-                >
-                  {ROLE_BADGE_LABEL[primaryRole]}
-                </span>
-              ) : null}
             </div>
             <button className="logout-btn" type="button" onClick={logout} title="登出 / Logout">
               <LogoutIcon />

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -10,23 +10,21 @@ import {
 import {
   clearSession,
   getAccessToken,
-  type UserRole,
 } from '../services/auth'
 import { getCurrentUser, type MeResponse } from '../services/user.api'
+import { getUiManifest } from '../services/uiManifest.api'
+import type { UiManifest } from '../types/uiManifest'
 
 interface AuthContextValue {
-  /** True while the initial /me fetch is in flight. Routes should render a loading state until this is false. */
+  /** True while the initial session + UI manifest fetch is in flight. */
   loading: boolean
   authenticated: boolean
   user: MeResponse | null
-  /** roles[0] — used to drive "primary" role-conditional UI (badge color, etc.) */
-  primaryRole: UserRole | null
-  isVolunteer: boolean
-  isSocialWorker: boolean
-  isManager: boolean
-  hasRole: (role: UserRole) => boolean
-  hasAnyRole: (...roles: UserRole[]) => boolean
-  /** Re-fetch /me. Call this after a successful login flow completes. */
+  manifest: UiManifest | null
+  canRoute: (routeId: string) => boolean
+  canFeature: (featureId: string) => boolean
+  canWidget: (widgetId: string) => boolean
+  /** Re-fetch profile + UI manifest. Call this after a successful login flow completes. */
   refreshUser: () => Promise<void>
   logout: () => void
 }
@@ -36,20 +34,27 @@ const AuthContext = createContext<AuthContextValue | null>(null)
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true)
   const [user, setUser] = useState<MeResponse | null>(null)
+  const [manifest, setManifest] = useState<UiManifest | null>(null)
 
   const refreshUser = useCallback(async () => {
     if (!getAccessToken()) {
       setUser(null)
+      setManifest(null)
       return
     }
     try {
-      const me = await getCurrentUser()
+      const [me, uiManifest] = await Promise.all([
+        getCurrentUser(),
+        getUiManifest(),
+      ])
       setUser(me)
+      setManifest(uiManifest)
     } catch {
       // Token invalid / expired / network failure — drop session so the user
       // gets bounced to the login page on the next protected-route render.
       clearSession()
       setUser(null)
+      setManifest(null)
     }
   }, [])
 
@@ -58,28 +63,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [refreshUser])
 
   const value = useMemo<AuthContextValue>(() => {
-    const roles = user?.roles ?? []
-    const has = (role: UserRole) => roles.includes(role)
-    const hasAny = (...rs: UserRole[]) => rs.some((r) => roles.includes(r))
+    const canRoute = (routeId: string) => Boolean(manifest?.routes.includes(routeId))
+    const canFeature = (featureId: string) => Boolean(manifest?.features.includes(featureId))
+    const canWidget = (widgetId: string) => Boolean(manifest?.widgets.includes(widgetId))
 
     return {
       loading,
-      authenticated: user !== null,
+      authenticated: user !== null && manifest !== null,
       user,
-      primaryRole: roles[0] ?? null,
-      isVolunteer: has('VOLUNTEER'),
-      isSocialWorker: has('SOCIAL_WORKER'),
-      isManager: has('MANAGER'),
-      hasRole: has,
-      hasAnyRole: hasAny,
+      manifest,
+      canRoute,
+      canFeature,
+      canWidget,
       refreshUser,
       logout: () => {
         clearSession()
         setUser(null)
+        setManifest(null)
         window.location.href = '/login'
       },
     }
-  }, [loading, user, refreshUser])
+  }, [loading, user, manifest, refreshUser])
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }

--- a/frontend/src/pages/clients/ClientDetailPage.tsx
+++ b/frontend/src/pages/clients/ClientDetailPage.tsx
@@ -29,16 +29,16 @@ interface TabDef {
   id: TabId
   zh: string
   en: string
-  swOnly?: boolean
+  detailOnly?: boolean
 }
 
 const TABS: TabDef[] = [
   { id: 'basic', zh: '基本信息', en: 'Basic Info' },
-  { id: 'identity', zh: '身份文件', en: 'Identity', swOnly: true },
-  { id: 'personal', zh: '个人信息', en: 'Personal', swOnly: true },
-  { id: 'ordination', zh: '受戒历史', en: 'Ordination', swOnly: true },
-  { id: 'wellbeing', zh: '健康评估', en: 'Wellbeing', swOnly: true },
-  { id: 'cases', zh: '关联个案', en: 'Cases', swOnly: true },
+  { id: 'identity', zh: '身份文件', en: 'Identity', detailOnly: true },
+  { id: 'personal', zh: '个人信息', en: 'Personal', detailOnly: true },
+  { id: 'ordination', zh: '受戒历史', en: 'Ordination', detailOnly: true },
+  { id: 'wellbeing', zh: '健康评估', en: 'Wellbeing', detailOnly: true },
+  { id: 'cases', zh: '关联个案', en: 'Cases', detailOnly: true },
 ]
 
 function InfoItem({ label, value }: { label: string; value: string | number | boolean | undefined }) {
@@ -197,7 +197,7 @@ function CasesTab({ clientId }: { clientId: string }) {
 
 export function ClientDetailPage() {
   const { id } = useParams<{ id: string }>()
-  const { isSocialWorker } = useAuth()
+  const { canFeature } = useAuth()
   const navigate = useNavigate()
   const [client, setClient] = useState<Client>()
   const [loading, setLoading] = useState(true)
@@ -220,7 +220,9 @@ export function ClientDetailPage() {
     return () => { active = false }
   }, [id])
 
-  const visibleTabs = isSocialWorker ? TABS : TABS.filter((t) => !t.swOnly)
+  const canViewDetailedProfile = canFeature('clients.view.full')
+  const canUpdateClient = canFeature('clients.update')
+  const visibleTabs = canViewDetailedProfile ? TABS : TABS.filter((t) => !t.detailOnly)
 
   if (loading) {
     return (
@@ -257,7 +259,7 @@ export function ClientDetailPage() {
             {client.membershipStatus}
           </span>
         </div>
-        {isSocialWorker && (
+        {canUpdateClient && (
           <button className="btn-primary" type="button" onClick={() => navigate(`/clients/${client.id}/edit`)}>
             编辑 / Edit
           </button>
@@ -278,15 +280,15 @@ export function ClientDetailPage() {
       </div>
 
       {activeTab === 'basic' && <BasicTab client={client} />}
-      {activeTab === 'identity' && isSocialWorker && <IdentityTab client={client} />}
-      {activeTab === 'personal' && isSocialWorker && <PersonalTab client={client} />}
-      {activeTab === 'ordination' && isSocialWorker && <OrdinationTab client={client} />}
-      {activeTab === 'wellbeing' && isSocialWorker && <WellbeingTab client={client} />}
-      {activeTab === 'cases' && isSocialWorker && <CasesTab clientId={client.id} />}
+      {activeTab === 'identity' && canViewDetailedProfile && <IdentityTab client={client} />}
+      {activeTab === 'personal' && canViewDetailedProfile && <PersonalTab client={client} />}
+      {activeTab === 'ordination' && canViewDetailedProfile && <OrdinationTab client={client} />}
+      {activeTab === 'wellbeing' && canViewDetailedProfile && <WellbeingTab client={client} />}
+      {activeTab === 'cases' && canViewDetailedProfile && <CasesTab clientId={client.id} />}
 
-      {!isSocialWorker && (
+      {!canViewDetailedProfile && (
         <div className="volunteer-notice">
-          如需查看完整档案，请联系 Social Worker。 / For full profile access, please contact a Social Worker.
+          如需查看完整档案，请联系负责人员。 / For full profile access, please contact the responsible staff.
         </div>
       )}
     </>

--- a/frontend/src/pages/clients/ClientFormPage.tsx
+++ b/frontend/src/pages/clients/ClientFormPage.tsx
@@ -57,13 +57,14 @@ function emptyClient(): Omit<Client, 'id'> {
 export function ClientFormPage() {
   const { id } = useParams<{ id: string }>()
   const isEdit = Boolean(id)
-  const { isSocialWorker } = useAuth()
+  const { canFeature } = useAuth()
   const navigate = useNavigate()
 
   const [step, setStep] = useState(0)
   const [form, setForm] = useState<Omit<Client, 'id'>>(emptyClient())
   const [loading, setLoading] = useState(isEdit)
   const [saving, setSaving] = useState(false)
+  const canWriteClient = isEdit ? canFeature('clients.update') : canFeature('clients.create')
 
   useEffect(() => {
     if (!id) return
@@ -85,13 +86,13 @@ export function ClientFormPage() {
     return () => { active = false }
   }, [id])
 
-  if (!isSocialWorker) {
+  if (!canWriteClient) {
     return (
       <>
         <h2 className="page-title">权限不足</h2>
         <div className="page-subtitle">Access Denied</div>
         <p style={{ marginTop: 16, color: 'var(--text-muted)', fontSize: 13 }}>
-          仅 Social Worker 可创建或编辑僧人档案。 / Only Social Workers can create or edit client profiles.
+          当前账户不可创建或编辑僧人档案。 / Your current access does not allow creating or editing client profiles.
         </p>
       </>
     )

--- a/frontend/src/pages/clients/ClientListPage.tsx
+++ b/frontend/src/pages/clients/ClientListPage.tsx
@@ -11,13 +11,15 @@ function MembershipBadge({ status }: { status: Client['membershipStatus'] }) {
 }
 
 export function ClientListPage() {
-  const { isSocialWorker } = useAuth()
+  const { canFeature } = useAuth()
   const navigate = useNavigate()
   const [clients, setClients] = useState<Client[]>([])
   const [search, setSearch] = useState('')
   const [filterStatus, setFilterStatus] = useState<string>('all')
   const [filterTradition, setFilterTradition] = useState<string>('all')
   const [loading, setLoading] = useState(true)
+  const canCreateClient = canFeature('clients.create')
+  const canUpdateClient = canFeature('clients.update')
 
   useEffect(() => {
     let active = true
@@ -84,7 +86,7 @@ export function ClientListPage() {
           <option value="Mahayana">Mahayana</option>
           <option value="Vajrayana">Vajrayana</option>
         </select>
-        {isSocialWorker && (
+        {canCreateClient && (
           <div className="toolbar-right">
             <button
               className="btn-primary"
@@ -148,10 +150,10 @@ export function ClientListPage() {
                           type="button"
                           onClick={() => navigate(`/clients/${c.id}`)}
                         >
-                          <span className="cell-zh">{isSocialWorker ? '查看档案' : '查看信息'}</span>
-                          <span className="cell-en">{isSocialWorker ? 'View Profile' : 'View Info'}</span>
+                          <span className="cell-zh">{canUpdateClient ? '查看档案' : '查看信息'}</span>
+                          <span className="cell-en">{canUpdateClient ? 'View Profile' : 'View Info'}</span>
                         </button>
-                        {isSocialWorker && (
+                        {canUpdateClient && (
                           <button
                             className="action-link"
                             type="button"

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -21,7 +21,7 @@ function formatHonorific(name: string): string {
 }
 
 export function DashboardPage() {
-  const { isSocialWorker } = useAuth()
+  const { canFeature, canRoute, canWidget } = useAuth()
   const navigate = useNavigate()
   const [dashboardData, setDashboardData] = useState<DashboardData>()
   const [errorMessage, setErrorMessage] = useState<string>()
@@ -56,6 +56,13 @@ export function DashboardPage() {
     () => dashboardData?.upcomingAppointments ?? [],
     [dashboardData],
   )
+  const canCreateClient = canFeature('clients.create')
+  const canCreateCase = canFeature('cases.create')
+  const canCreateReport = canFeature('reports.create')
+  const canViewCases = canRoute('cases.list')
+  const showActiveCases = canWidget('dashboard.activeCases')
+  const showUrgentCases = canWidget('dashboard.urgentCases')
+  const showUpcomingAppointments = canWidget('dashboard.upcomingAppointments')
 
   return (
     <>
@@ -71,8 +78,7 @@ export function DashboardPage() {
           <div className="card-title">快速操作</div>
           <div className="card-subtitle">Quick Actions</div>
           <div className="quick-actions quick-actions-spacing">
-            {isSocialWorker && (
-              <>
+            {canCreateClient ? (
                 <button className="quick-btn" type="button" onClick={() => navigate('/clients/new')}>
                   <span className="quick-icon">＋</span>
                   <span className="quick-label">
@@ -80,6 +86,8 @@ export function DashboardPage() {
                     <span className="en">New Client</span>
                   </span>
                 </button>
+            ) : null}
+            {canCreateCase ? (
                 <button className="quick-btn" type="button" onClick={() => navigate('/cases/new')}>
                   <span className="quick-icon">＋</span>
                   <span className="quick-label">
@@ -87,6 +95,8 @@ export function DashboardPage() {
                     <span className="en">New Case</span>
                   </span>
                 </button>
+            ) : null}
+            {canViewCases ? (
                 <button className="quick-btn" type="button" onClick={() => navigate('/cases')}>
                   <span className="quick-icon">📋</span>
                   <span className="quick-label">
@@ -94,62 +104,66 @@ export function DashboardPage() {
                     <span className="en">View My Cases</span>
                   </span>
                 </button>
-              </>
-            )}
-            <button className="quick-btn" type="button" onClick={() => navigate('/reports/new')}>
-              <span className="quick-icon">📄</span>
-              <span className="quick-label">
-                <span className="zh">提交探访报告</span>
-                <span className="en">Submit Report</span>
-              </span>
-            </button>
+            ) : null}
+            {canCreateReport ? (
+              <button className="quick-btn" type="button" onClick={() => navigate('/reports/new')}>
+                <span className="quick-icon">📄</span>
+                <span className="quick-label">
+                  <span className="zh">提交探访报告</span>
+                  <span className="en">Submit Report</span>
+                </span>
+              </button>
+            ) : null}
           </div>
         </div>
       </section>
 
-      {isSocialWorker && (
+      {(showActiveCases || showUrgentCases) && (
         <>
-          <section className="card" aria-label="My Active Cases">
-            <div className="card-header">
-              <div className="card-title">我的活跃个案</div>
-              <div className="card-subtitle">My Active Cases</div>
-            </div>
-            <div className="table-wrap">
-              <table>
-                <colgroup>
-                  <col className="col-title" />
-                  <col className="col-client" />
-                  <col className="col-status" />
-                  <col className="col-actions" />
-                </colgroup>
-                <thead>
-                  <tr>
-                    <th><span className="th-zh">标题</span><span className="th-en">Title</span></th>
-                    <th><span className="th-zh">服务对象</span><span className="th-en">Client</span></th>
-                    <th><span className="th-zh">状态</span><span className="th-en">Status</span></th>
-                    <th className="action-cell-left"><span className="th-zh">操作</span><span className="th-en">Actions</span></th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {activeCases.map((item) => (
-                    <tr key={item.id}>
-                      <td><span className="cell-zh">{item.title.zh}</span><span className="cell-en">{item.title.en}</span></td>
-                      <td><span className="cell-zh">{item.client.zh}</span><span className="cell-en">{formatHonorific(item.client.en)}</span></td>
-                      <td><StatusBadge status={item.status} /></td>
-                      <td className="action-cell action-cell-left">
-                        <button className="action-link" type="button">
-                          <span className="cell-zh">查看</span>
-                          <span className="cell-en">View</span>
-                        </button>
-                      </td>
+          {showActiveCases ? (
+            <section className="card" aria-label="My Active Cases">
+              <div className="card-header">
+                <div className="card-title">我的活跃个案</div>
+                <div className="card-subtitle">My Active Cases</div>
+              </div>
+              <div className="table-wrap">
+                <table>
+                  <colgroup>
+                    <col className="col-title" />
+                    <col className="col-client" />
+                    <col className="col-status" />
+                    <col className="col-actions" />
+                  </colgroup>
+                  <thead>
+                    <tr>
+                      <th><span className="th-zh">标题</span><span className="th-en">Title</span></th>
+                      <th><span className="th-zh">服务对象</span><span className="th-en">Client</span></th>
+                      <th><span className="th-zh">状态</span><span className="th-en">Status</span></th>
+                      <th className="action-cell-left"><span className="th-zh">操作</span><span className="th-en">Actions</span></th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </section>
+                  </thead>
+                  <tbody>
+                    {activeCases.map((item) => (
+                      <tr key={item.id}>
+                        <td><span className="cell-zh">{item.title.zh}</span><span className="cell-en">{item.title.en}</span></td>
+                        <td><span className="cell-zh">{item.client.zh}</span><span className="cell-en">{formatHonorific(item.client.en)}</span></td>
+                        <td><StatusBadge status={item.status} /></td>
+                        <td className="action-cell action-cell-left">
+                          <button className="action-link" type="button">
+                            <span className="cell-zh">查看</span>
+                            <span className="cell-en">View</span>
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          ) : null}
 
-          <section className="card" aria-label="Cases Needing Attention">
+          {showUrgentCases ? (
+            <section className="card" aria-label="Cases Needing Attention">
             <div className="card-header">
               <div className="card-title">需要关注的个案</div>
               <div className="card-subtitle">Cases Needing Attention</div>
@@ -185,10 +199,12 @@ export function DashboardPage() {
               </table>
             </div>
           </section>
+          ) : null}
         </>
       )}
 
-      <section className="card" aria-label="Upcoming Appointments">
+      {showUpcomingAppointments ? (
+        <section className="card" aria-label="Upcoming Appointments">
         <div className="card-header">
           <div className="card-title">即将到来的预约</div>
           <div className="card-subtitle">Upcoming Appointments</div>
@@ -230,6 +246,7 @@ export function DashboardPage() {
           </table>
         </div>
       </section>
+      ) : null}
     </>
   )
 }

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -75,7 +75,7 @@ export function LoginPage() {
         return
       }
 
-      // 登录成功且无需 2FA — 先拉 /me 填角色，再跳。
+      // 登录成功且无需 2FA — 先拉 profile + manifest，再跳。
       await refreshUser()
       navigate('/dashboard', { replace: true })
     } catch (error) {

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -2,17 +2,9 @@ import { http } from './http'
 
 const ACCESS_TOKEN_KEY = 'aranya_access_token'
 const REFRESH_TOKEN_KEY = 'aranya_refresh_token'
-// Legacy keys from the pre-decoupled-auth design where role/profile state was
-// persisted in localStorage. Kept here only so clearSession can wipe stale
-// values from existing dev sessions; nothing reads or writes them.
+// Legacy profile keys from older dev sessions. Nothing reads or writes them.
 const LEGACY_USER_EMAIL_KEY = 'aranya_user_email'
 const LEGACY_USER_NAME_KEY = 'aranya_user_name'
-const LEGACY_USER_ROLES_KEY = 'aranya_user_roles'
-const LEGACY_USER_ROLE_KEY = 'aranya_user_role'
-
-export type UserRole = 'VOLUNTEER' | 'SOCIAL_WORKER' | 'MANAGER'
-
-export const ALL_ROLES: UserRole[] = ['VOLUNTEER', 'SOCIAL_WORKER', 'MANAGER']
 
 export interface LoginPayload {
   email: string
@@ -75,8 +67,8 @@ export async function enableTwoFactorInit(payload: TwoFactorInitEnablePayload): 
 }
 
 /**
- * Persist auth tokens only. User identity and roles are NOT cached in
- * localStorage — AuthContext fetches them from `/users/me` on demand.
+ * Persist auth tokens only. User identity and render instructions are NOT
+ * cached in localStorage — AuthContext fetches them on demand.
  */
 export function persistSession(session: LoginResponse): void {
   localStorage.setItem(ACCESS_TOKEN_KEY, session.accessToken)
@@ -89,8 +81,6 @@ export function clearSession(): void {
   // Defensive cleanup of legacy keys from older sessions.
   localStorage.removeItem(LEGACY_USER_EMAIL_KEY)
   localStorage.removeItem(LEGACY_USER_NAME_KEY)
-  localStorage.removeItem(LEGACY_USER_ROLES_KEY)
-  localStorage.removeItem(LEGACY_USER_ROLE_KEY)
 }
 
 export function getAccessToken(): string | null {

--- a/frontend/src/services/uiManifest.api.ts
+++ b/frontend/src/services/uiManifest.api.ts
@@ -1,0 +1,7 @@
+import { http } from './http'
+import type { UiManifest } from '../types/uiManifest'
+
+export async function getUiManifest(): Promise<UiManifest> {
+  const { data } = await http.get<UiManifest>('/v1/ui/manifest')
+  return data
+}

--- a/frontend/src/services/user.api.ts
+++ b/frontend/src/services/user.api.ts
@@ -1,21 +1,11 @@
 import { http } from './http'
-import type { UserRole } from './auth'
-
 export interface MeResponse {
   id: number
   email: string
   fullName: string
-  roles: UserRole[]
 }
 
-/**
- * Fetch the currently-authenticated user's profile and roles.
- *
- * Called by AuthContext on app init (if a token exists) and after every
- * successful login flow (incl. 2FA verify / setup). The backend resolves
- * the caller from SecurityContext.principal — we don't pass any identity
- * in the request body.
- */
+/** Fetch the currently-authenticated user's basic profile. */
 export async function getCurrentUser(): Promise<MeResponse> {
   const { data } = await http.get<MeResponse>('/v1/users/me')
   return data

--- a/frontend/src/types/uiManifest.ts
+++ b/frontend/src/types/uiManifest.ts
@@ -1,0 +1,5 @@
+export interface UiManifest {
+  routes: string[]
+  features: string[]
+  widgets: string[]
+}


### PR DESCRIPTION
- add DB-backed permission and role_permission capability mapping
- expose GET /api/v1/ui/manifest with routes/features/widgets only
- remove roles from /users/me and keep profile response role-free
- update AuthContext to load profile plus capability manifest
- replace frontend role checks with canRoute/canFeature/canWidget
- make sidebar and route guards capability-driven
- document the capability sitemap and frontend/backend ownership boundary