### PR TITLE
feature/add JPA entities for business database schema

### DIFF
--- a/backend/src/main/java/aranya/crm/entity/CaseAssignment.java
+++ b/backend/src/main/java/aranya/crm/entity/CaseAssignment.java
@@ -1,0 +1,61 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "case_assignment")
+public class CaseAssignment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "case_id", nullable = false)
+    private ClientCase clientCase;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "is_primary", nullable = false)
+    private boolean primary = false;
+
+    @Column(name = "assignment_role", nullable = false, length = 50)
+    private String assignmentRole;
+
+    @Column(name = "status", nullable = false, length = 20)
+    private String status = "ACTIVE";
+
+    @Column(name = "assigned_at", nullable = false, updatable = false)
+    private LocalDateTime assignedAt;
+
+    @Column(name = "end_at")
+    private LocalDateTime endAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assigned_by")
+    private User assignedBy;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.assignedAt == null) {
+            this.assignedAt = LocalDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/aranya/crm/entity/CaseChangeLog.java
+++ b/backend/src/main/java/aranya/crm/entity/CaseChangeLog.java
@@ -1,0 +1,57 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "case_change_log")
+public class CaseChangeLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "case_id", nullable = false)
+    private ClientCase clientCase;
+
+    @Column(name = "field_name", nullable = false, length = 100)
+    private String fieldName;
+
+    @Column(name = "old_value", columnDefinition = "TEXT")
+    private String oldValue;
+
+    @Column(name = "new_value", nullable = false, columnDefinition = "TEXT")
+    private String newValue;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "changed_by", nullable = false)
+    private User changedBy;
+
+    @Column(name = "changed_at", nullable = false, updatable = false)
+    private LocalDateTime changedAt;
+
+    @Column(name = "remarks", columnDefinition = "TEXT")
+    private String remarks;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.changedAt == null) {
+            this.changedAt = LocalDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/aranya/crm/entity/CaseDocument.java
+++ b/backend/src/main/java/aranya/crm/entity/CaseDocument.java
@@ -1,0 +1,49 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "case_document")
+public class CaseDocument {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "case_id", nullable = false)
+    private ClientCase clientCase;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "document_id", nullable = false)
+    private Document document;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "linked_by")
+    private User linkedBy;
+
+    @Column(name = "linked_at", nullable = false, updatable = false)
+    private LocalDateTime linkedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.linkedAt == null) {
+            this.linkedAt = LocalDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/aranya/crm/entity/CaseNote.java
+++ b/backend/src/main/java/aranya/crm/entity/CaseNote.java
@@ -1,0 +1,57 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "case_note")
+public class CaseNote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "case_id", nullable = false)
+    private ClientCase clientCase;
+
+    @Column(name = "note_type", length = 50)
+    private String noteType;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "visibility", nullable = false, length = 20)
+    private String visibility = "INTERNAL";
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by")
+    private User createdBy;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/aranya/crm/entity/Client.java
+++ b/backend/src/main/java/aranya/crm/entity/Client.java
@@ -1,0 +1,179 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "client")
+public class Client {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "abbr", nullable = false, unique = true, length = 20)
+    private String abbr;
+
+    @Column(name = "name_en", nullable = false, length = 150)
+    private String nameEn;
+
+    @Column(name = "name_chn", length = 100)
+    private String nameChn;
+
+    @Column(length = 20)
+    private String contact;
+
+    @Column(name = "preferred_communication", length = 50)
+    private String preferredCommunication;
+
+    @Column(name = "whatsapp_enabled", nullable = false)
+    private boolean whatsappEnabled = false;
+
+    @Column(name = "preferred_language", length = 50)
+    private String preferredLanguage;
+
+    @Column(name = "spoken_language", length = 100)
+    private String spokenLanguage;
+
+    @Column(name = "address_text", columnDefinition = "TEXT")
+    private String addressText;
+
+    @Column(name = "postal_code", length = 20)
+    private String postalCode;
+
+    @Column(name = "area_district", length = 100)
+    private String areaDistrict;
+
+    @Column(name = "vihara_type", length = 50)
+    private String viharaType;
+
+    @Column(name = "nric_name_en", length = 150)
+    private String nricNameEn;
+
+    @Column(name = "nric_name_chn", length = 100)
+    private String nricNameChn;
+
+    @Column(name = "nric_no", length = 50)
+    private String nricNo;
+
+    @Column(name = "ordination_certificate_status", length = 20)
+    private String ordinationCertificateStatus;
+
+    @Column(name = "date_of_verification")
+    private LocalDate dateOfVerification;
+
+    @Column(length = 10)
+    private String gender;
+
+    @Column(name = "date_of_birth")
+    private LocalDate dateOfBirth;
+
+    @Column(name = "marital_status", length = 30)
+    private String maritalStatus;
+
+    @Column(length = 50)
+    private String nationality;
+
+    @Column(length = 50)
+    private String ethnicity;
+
+    @Column(name = "dialect_group", length = 50)
+    private String dialectGroup;
+
+    @Column(name = "membership_status", nullable = false, length = 30)
+    private String membershipStatus = "ACTIVE";
+
+    @Column(name = "date_joined")
+    private LocalDate dateJoined;
+
+    @Column(name = "membership_remarks", columnDefinition = "TEXT")
+    private String membershipRemarks;
+
+    @Column(name = "buddhist_tradition", length = 30)
+    private String buddhistTradition;
+
+    @Column(name = "ordination_status", length = 30)
+    private String ordinationStatus;
+
+    @Column(name = "date_of_tonsure")
+    private LocalDate dateOfTonsure;
+
+    @Column(name = "country_of_tonsure", length = 50)
+    private String countryOfTonsure;
+
+    @Column(name = "place_of_tonsure", length = 100)
+    private String placeOfTonsure;
+
+    @Column(name = "date_of_ordination")
+    private LocalDate dateOfOrdination;
+
+    @Column(name = "country_of_ordination", length = 50)
+    private String countryOfOrdination;
+
+    @Column(name = "place_of_ordination", length = 100)
+    private String placeOfOrdination;
+
+    @Column(name = "wellbeing_living_conditions", nullable = false)
+    private boolean wellbeingLivingConditions = false;
+
+    @Column(name = "wellbeing_mental_health", nullable = false)
+    private boolean wellbeingMentalHealth = false;
+
+    @Column(name = "wellbeing_physical_health", nullable = false)
+    private boolean wellbeingPhysicalHealth = false;
+
+    @Column(name = "wellbeing_financial_stability", nullable = false)
+    private boolean wellbeingFinancialStability = false;
+
+    @Column(name = "wellbeing_social_support", nullable = false)
+    private boolean wellbeingSocialSupport = false;
+
+    @Column(name = "wellbeing_legal_issues", nullable = false)
+    private boolean wellbeingLegalIssues = false;
+
+    @Column(name = "wellbeing_spiritual", nullable = false)
+    private boolean wellbeingSpiritual = false;
+
+    @Column(name = "wellbeing_remarks", columnDefinition = "TEXT")
+    private String wellbeingRemarks;
+
+    @Column(name = "special_needs", length = 100)
+    private String specialNeeds;
+
+    @Column(name = "special_needs_remarks", columnDefinition = "TEXT")
+    private String specialNeedsRemarks;
+
+    @Column(name = "bank_transfer_info", length = 100)
+    private String bankTransferInfo;
+
+    @Column(name = "pay_now_info", length = 100)
+    private String payNowInfo;
+
+    @Column(name = "next_of_kin_contact", length = 100)
+    private String nextOfKinContact;
+
+    @Column(columnDefinition = "TEXT")
+    private String comments;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/aranya/crm/entity/ClientCase.java
+++ b/backend/src/main/java/aranya/crm/entity/ClientCase.java
@@ -1,0 +1,82 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "case")
+public class ClientCase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "case_code", nullable = false, unique = true, length = 50)
+    private String caseCode;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "client_id", nullable = false)
+    private Client client;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "priority", nullable = false, length = 20)
+    private String priority = "NORMAL";
+
+    @Column(name = "status", nullable = false, length = 20)
+    private String status = "OPEN";
+
+    @Column(name = "color_code", length = 20)
+    private String colorCode;
+
+    @Column(name = "tradition", length = 30)
+    private String tradition;
+
+    @Column(name = "opened_at", nullable = false)
+    private LocalDateTime openedAt;
+
+    @Column(name = "closed_at")
+    private LocalDateTime closedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by", nullable = false)
+    private User createdBy;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "comments", columnDefinition = "TEXT")
+    private String comments;
+
+    @Column(name = "remarks", columnDefinition = "TEXT")
+    private String remarks;
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        if (this.openedAt == null) {
+            this.openedAt = now;
+        }
+        if (this.createdAt == null) {
+            this.createdAt = now;
+        }
+    }
+}

--- a/backend/src/main/java/aranya/crm/entity/Document.java
+++ b/backend/src/main/java/aranya/crm/entity/Document.java
@@ -1,0 +1,74 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "document")
+public class Document {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "file_name", nullable = false)
+    private String fileName;
+
+    @Column(name = "store_name", nullable = false)
+    private String storeName;
+
+    @Column(name = "s3_bucket")
+    private String s3Bucket;
+
+    @Column(name = "s3_key", length = 500)
+    private String s3Key;
+
+    @Column(name = "mime_type", length = 100)
+    private String mimeType;
+
+    @Column(name = "file_size")
+    private Long fileSize;
+
+    @Column(name = "document_type", length = 50)
+    private String documentType;
+
+    @Column(name = "status", nullable = false, length = 20)
+    private String status = "ACTIVE";
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "uploaded_by")
+    private User uploadedBy;
+
+    @Column(name = "uploaded_at", nullable = false, updatable = false)
+    private LocalDateTime uploadedAt;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "checksum")
+    private String checksum;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.uploadedAt == null) {
+            this.uploadedAt = LocalDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/aranya/crm/entity/EmailNotificationLog.java
+++ b/backend/src/main/java/aranya/crm/entity/EmailNotificationLog.java
@@ -1,0 +1,54 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "email_notification_log")
+public class EmailNotificationLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "send_user_id", nullable = false)
+    private User sendUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipient_user_id")
+    private User recipientUser;
+
+    @Column(name = "recipient_email", nullable = false, length = 100)
+    private String recipientEmail;
+
+    @Column(name = "source_type", nullable = false, length = 50)
+    private String sourceType;
+
+    @Column(name = "source_id")
+    private Long sourceId;
+
+    @Column(name = "send_at", nullable = false, updatable = false)
+    private LocalDateTime sendAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.sendAt == null) {
+            this.sendAt = LocalDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/aranya/crm/entity/Invitation.java
+++ b/backend/src/main/java/aranya/crm/entity/Invitation.java
@@ -1,0 +1,60 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "invitation")
+public class Invitation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "email", nullable = false, length = 100)
+    private String email;
+
+    @Column(name = "token", nullable = false, unique = true)
+    private String token;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assigned_role_id", nullable = false)
+    private Role assignedRole;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invited_by", nullable = false)
+    private User invitedBy;
+
+    @Column(name = "status", nullable = false, length = 20)
+    private String status = "PENDING";
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "accepted_at")
+    private LocalDateTime acceptedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/aranya/crm/entity/Permission.java
+++ b/backend/src/main/java/aranya/crm/entity/Permission.java
@@ -1,0 +1,34 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(
+        name = "permission",
+        uniqueConstraints = @UniqueConstraint(name = "uq_permission_code_type", columnNames = {"code", "type"})
+)
+public class Permission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "code", nullable = false, length = 100)
+    private String code;
+
+    @Column(name = "type", nullable = false, length = 20)
+    private String type;
+
+    @Column(name = "description")
+    private String description;
+}

--- a/backend/src/main/java/aranya/crm/entity/RelatedContact.java
+++ b/backend/src/main/java/aranya/crm/entity/RelatedContact.java
@@ -1,0 +1,62 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "related_contact")
+public class RelatedContact {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "client_id", nullable = false)
+    private Client client;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "relationship_type", length = 50)
+    private String relationshipType;
+
+    @Column(name = "phone", length = 20)
+    private String phone;
+
+    @Column(name = "email", length = 100)
+    private String email;
+
+    @Column(name = "address_text", columnDefinition = "TEXT")
+    private String addressText;
+
+    @Column(name = "is_primary", nullable = false)
+    private boolean primary = false;
+
+    @Column(name = "notes", columnDefinition = "TEXT")
+    private String notes;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/aranya/crm/entity/RolePermission.java
+++ b/backend/src/main/java/aranya/crm/entity/RolePermission.java
@@ -1,0 +1,38 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(
+        name = "role_permission",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_role_permission_role_id_permission_id",
+                columnNames = {"role_id", "permission_id"}
+        )
+)
+public class RolePermission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "role_id", nullable = false)
+    private Role role;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "permission_id", nullable = false)
+    private Permission permission;
+}

--- a/backend/src/main/java/aranya/crm/entity/ServiceAppointment.java
+++ b/backend/src/main/java/aranya/crm/entity/ServiceAppointment.java
@@ -1,0 +1,68 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "service_appointment")
+public class ServiceAppointment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "case_id", nullable = false)
+    private ClientCase clientCase;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "service_type_id", nullable = false)
+    private ServiceType serviceType;
+
+    @Column(name = "scheduled_start", nullable = false)
+    private LocalDateTime scheduledStart;
+
+    @Column(name = "scheduled_end")
+    private LocalDateTime scheduledEnd;
+
+    @Column(name = "location")
+    private String location;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assigned_user_id")
+    private User assignedUser;
+
+    @Column(name = "status", nullable = false, length = 20)
+    private String status = "SCHEDULED";
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by")
+    private User createdBy;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/aranya/crm/entity/ServiceCategory.java
+++ b/backend/src/main/java/aranya/crm/entity/ServiceCategory.java
@@ -1,0 +1,50 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "service_category")
+public class ServiceCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, unique = true, length = 100)
+    private String name;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active = true;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by")
+    private User createdBy;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/aranya/crm/entity/ServiceType.java
+++ b/backend/src/main/java/aranya/crm/entity/ServiceType.java
@@ -1,0 +1,58 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(
+        name = "service_type",
+        uniqueConstraints = @UniqueConstraint(name = "uq_service_type_category_name", columnNames = {"category_id", "name"})
+)
+public class ServiceType {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private ServiceCategory category;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active = true;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by")
+    private User createdBy;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/aranya/crm/entity/VisitReport.java
+++ b/backend/src/main/java/aranya/crm/entity/VisitReport.java
@@ -1,0 +1,101 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "visit_report")
+public class VisitReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "client_id", nullable = false)
+    private Client client;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by")
+    private User createdBy;
+
+    @Column(name = "staff_name", length = 150)
+    private String staffName;
+
+    @Column(name = "report_timestamp", nullable = false)
+    private LocalDateTime reportTimestamp;
+
+    @Column(name = "date_of_visit", nullable = false)
+    private LocalDate dateOfVisit;
+
+    @Column(name = "time_of_visit", length = 20)
+    private String timeOfVisit;
+
+    @Column(name = "duration_of_visit", length = 50)
+    private String durationOfVisit;
+
+    @Column(name = "location")
+    private String location;
+
+    @Column(name = "programme_name")
+    private String programmeName;
+
+    @Column(name = "type_of_visit", length = 100)
+    private String typeOfVisit;
+
+    @Column(name = "purpose_of_visit", columnDefinition = "TEXT")
+    private String purposeOfVisit;
+
+    @Column(name = "what_was_done", columnDefinition = "TEXT")
+    private String whatWasDone;
+
+    @Column(name = "environment_observations", columnDefinition = "TEXT")
+    private String environmentObservations;
+
+    @Column(name = "sangha_observations", columnDefinition = "TEXT")
+    private String sanghaObservations;
+
+    @Column(name = "other_observations", columnDefinition = "TEXT")
+    private String otherObservations;
+
+    @Column(name = "personal_reflections", columnDefinition = "TEXT")
+    private String personalReflections;
+
+    @Column(name = "recommendations", columnDefinition = "TEXT")
+    private String recommendations;
+
+    @Column(name = "matters_to_highlight", columnDefinition = "TEXT")
+    private String mattersToHighlight;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        if (this.reportTimestamp == null) {
+            this.reportTimestamp = now;
+        }
+        if (this.createdAt == null) {
+            this.createdAt = now;
+        }
+    }
+}

--- a/backend/src/test/java/aranya/crm/entity/BusinessEntityMappingTest.java
+++ b/backend/src/test/java/aranya/crm/entity/BusinessEntityMappingTest.java
@@ -1,0 +1,87 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BusinessEntityMappingTest {
+
+    @Test
+    @DisplayName("All database tables have matching JPA entities")
+    void allDatabaseTables_haveMatchingJpaEntities() {
+        Map<Class<?>, String> mappings = Map.ofEntries(
+                Map.entry(Invitation.class, "invitation"),
+                Map.entry(EmailNotificationLog.class, "email_notification_log"),
+                Map.entry(RelatedContact.class, "related_contact"),
+                Map.entry(ClientCase.class, "case"),
+                Map.entry(ServiceCategory.class, "service_category"),
+                Map.entry(ServiceType.class, "service_type"),
+                Map.entry(CaseAssignment.class, "case_assignment"),
+                Map.entry(CaseNote.class, "case_note"),
+                Map.entry(ServiceAppointment.class, "service_appointment"),
+                Map.entry(Document.class, "document"),
+                Map.entry(CaseChangeLog.class, "case_change_log"),
+                Map.entry(CaseDocument.class, "case_document"),
+                Map.entry(VisitReport.class, "visit_report"),
+                Map.entry(Permission.class, "permission"),
+                Map.entry(RolePermission.class, "role_permission")
+        );
+
+        mappings.forEach((entityClass, tableName) -> {
+            Table table = entityClass.getAnnotation(Table.class);
+            assertThat(table).as(entityClass.getSimpleName()).isNotNull();
+            assertThat(table.name()).as(entityClass.getSimpleName()).isEqualTo(tableName);
+        });
+    }
+
+    @Test
+    @DisplayName("Foreign key fields use lazy many-to-one associations")
+    void foreignKeyFields_useLazyManyToOneAssociations() throws Exception {
+        assertManyToOne(RelatedContact.class, "client", "client_id", false);
+        assertManyToOne(ClientCase.class, "client", "client_id", false);
+        assertManyToOne(ClientCase.class, "createdBy", "created_by", false);
+        assertManyToOne(ServiceType.class, "category", "category_id", false);
+        assertManyToOne(CaseAssignment.class, "clientCase", "case_id", false);
+        assertManyToOne(CaseAssignment.class, "user", "user_id", false);
+        assertManyToOne(ServiceAppointment.class, "serviceType", "service_type_id", false);
+        assertManyToOne(CaseDocument.class, "document", "document_id", false);
+        assertManyToOne(RolePermission.class, "permission", "permission_id", false);
+    }
+
+    @Test
+    @DisplayName("Entities initialize schema defaults")
+    void entities_initializeSchemaDefaults() {
+        assertThat(new ClientCase().getPriority()).isEqualTo("NORMAL");
+        assertThat(new ClientCase().getStatus()).isEqualTo("OPEN");
+        assertThat(new ServiceCategory().isActive()).isTrue();
+        assertThat(new ServiceType().isActive()).isTrue();
+        assertThat(new CaseAssignment().isPrimary()).isFalse();
+        assertThat(new CaseAssignment().getStatus()).isEqualTo("ACTIVE");
+        assertThat(new CaseNote().getVisibility()).isEqualTo("INTERNAL");
+        assertThat(new ServiceAppointment().getStatus()).isEqualTo("SCHEDULED");
+        assertThat(new Document().getStatus()).isEqualTo("ACTIVE");
+        assertThat(new Permission().getType()).isNull();
+    }
+
+    private static void assertManyToOne(
+            Class<?> entityClass,
+            String fieldName,
+            String joinColumnName,
+            boolean nullable
+    ) throws Exception {
+        Field field = entityClass.getDeclaredField(fieldName);
+        assertThat(field.getAnnotation(ManyToOne.class)).isNotNull();
+
+        JoinColumn joinColumn = field.getAnnotation(JoinColumn.class);
+        assertThat(joinColumn).isNotNull();
+        assertThat(joinColumn.name()).isEqualTo(joinColumnName);
+        assertThat(joinColumn.nullable()).isEqualTo(nullable);
+    }
+}

--- a/backend/src/test/java/aranya/crm/entity/ClientEntityTest.java
+++ b/backend/src/test/java/aranya/crm/entity/ClientEntityTest.java
@@ -1,0 +1,59 @@
+package aranya.crm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Table;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ClientEntityTest {
+
+    @Test
+    @DisplayName("Client maps to the client table with core schema fields")
+    void client_mapsToClientTableWithCoreSchemaFields() throws Exception {
+        Table table = Client.class.getAnnotation(Table.class);
+
+        assertThat(table).isNotNull();
+        assertThat(table.name()).isEqualTo("client");
+        assertColumn("abbr", "abbr", 20, false, true);
+        assertColumn("nameEn", "name_en", 150, false, false);
+        assertColumn("whatsappEnabled", "whatsapp_enabled", 255, false, false);
+        assertColumn("nextOfKinContact", "next_of_kin_contact", 100, true, false);
+    }
+
+    @Test
+    @DisplayName("Client initializes database defaults used by the schema")
+    void client_initializesDatabaseDefaults() {
+        Client client = new Client();
+
+        assertThat(client.isWhatsappEnabled()).isFalse();
+        assertThat(client.isWellbeingLivingConditions()).isFalse();
+        assertThat(client.isWellbeingMentalHealth()).isFalse();
+        assertThat(client.isWellbeingPhysicalHealth()).isFalse();
+        assertThat(client.isWellbeingFinancialStability()).isFalse();
+        assertThat(client.isWellbeingSocialSupport()).isFalse();
+        assertThat(client.isWellbeingLegalIssues()).isFalse();
+        assertThat(client.isWellbeingSpiritual()).isFalse();
+        assertThat(client.getMembershipStatus()).isEqualTo("ACTIVE");
+    }
+
+    private static void assertColumn(
+            String fieldName,
+            String columnName,
+            int length,
+            boolean nullable,
+            boolean unique
+    ) throws Exception {
+        Field field = Client.class.getDeclaredField(fieldName);
+        Column column = field.getAnnotation(Column.class);
+
+        assertThat(column).isNotNull();
+        assertThat(column.name()).isEqualTo(columnName);
+        assertThat(column.length()).isEqualTo(length);
+        assertThat(column.nullable()).isEqualTo(nullable);
+        assertThat(column.unique()).isEqualTo(unique);
+    }
+}


### PR DESCRIPTION
Add JPA entity mappings for the CRM business domain tables defined in the Liquibase schema, including client, case, document, visit report, service configuration, appointment, contact, permission, and audit/log related models.

Implemented entities include:
- Client and RelatedContact
- ClientCase, CaseAssignment, CaseNote, CaseChangeLog, CaseDocument
- ServiceCategory, ServiceType, ServiceAppointment
- Document and VisitReport
- Invitation, EmailNotificationLog
- Permission and RolePermission

client                 -> Client
case                   -> ClientCase
document               -> Document
case_document          -> CaseDocument
visit_report           -> VisitReport
related_contact        -> RelatedContact
service_category       -> ServiceCategory
service_type           -> ServiceType
service_appointment    -> ServiceAppointment
case_assignment        -> CaseAssignment
case_note              -> CaseNote
case_change_log        -> CaseChangeLog
users                  -> User
role                   -> Role
user_role              -> UserRole
permission             -> Permission
role_permission        -> RolePermission
invitation             -> Invitation
refresh_token          -> RefreshToken
two_factor_backup_code -> TwoFactorBackupCode
email_notification_log -> EmailNotificationLog