### PR TITLE
feature/add JPA entities for business database schema

### DIFF
--- a/backend/src/main/java/aranya/crm/controller/ClientController.java
+++ b/backend/src/main/java/aranya/crm/controller/ClientController.java
@@ -1,0 +1,37 @@
+package aranya.crm.controller;
+
+import aranya.crm.dto.ClientDetailResponse;
+import aranya.crm.dto.ClientSummaryResponse;
+import aranya.crm.service.ClientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/clients")
+@RequiredArgsConstructor
+@PreAuthorize("isAuthenticated()")
+public class ClientController {
+
+    private final ClientService clientService;
+
+    @GetMapping
+    public ResponseEntity<List<ClientSummaryResponse>> listClients(
+            @RequestParam(required = false) String q,
+            @RequestParam(required = false) String membershipStatus
+    ) {
+        return ResponseEntity.ok(clientService.listClients(q, membershipStatus));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ClientDetailResponse> getClientDetail(@PathVariable Long id) {
+        return ResponseEntity.ok(clientService.getClientDetail(id));
+    }
+}

--- a/backend/src/main/java/aranya/crm/dto/ClientDetailResponse.java
+++ b/backend/src/main/java/aranya/crm/dto/ClientDetailResponse.java
@@ -1,0 +1,53 @@
+package aranya.crm.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class ClientDetailResponse {
+    private Long id;
+    private String abbr;
+    private String nameEn;
+    private String nameChn;
+    private String contact;
+    private String preferredCommunication;
+    private boolean whatsappEnabled;
+    private String preferredLanguage;
+    private String spokenLanguage;
+    private String addressText;
+    private String postalCode;
+    private String areaDistrict;
+    private String viharaType;
+    private String gender;
+    private LocalDate dateOfBirth;
+    private String maritalStatus;
+    private String nationality;
+    private String ethnicity;
+    private String dialectGroup;
+    private String membershipStatus;
+    private LocalDate dateJoined;
+    private String membershipRemarks;
+    private String buddhistTradition;
+    private String ordinationStatus;
+    private boolean wellbeingLivingConditions;
+    private boolean wellbeingMentalHealth;
+    private boolean wellbeingPhysicalHealth;
+    private boolean wellbeingFinancialStability;
+    private boolean wellbeingSocialSupport;
+    private boolean wellbeingLegalIssues;
+    private boolean wellbeingSpiritual;
+    private String wellbeingRemarks;
+    private String specialNeeds;
+    private String specialNeedsRemarks;
+    private String nextOfKinContact;
+    private String comments;
+    private LocalDateTime createdAt;
+    private List<RelatedContactResponse> relatedContacts;
+}

--- a/backend/src/main/java/aranya/crm/dto/ClientSummaryResponse.java
+++ b/backend/src/main/java/aranya/crm/dto/ClientSummaryResponse.java
@@ -1,0 +1,22 @@
+package aranya.crm.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class ClientSummaryResponse {
+    private Long id;
+    private String abbr;
+    private String nameEn;
+    private String nameChn;
+    private String contact;
+    private String preferredCommunication;
+    private String preferredLanguage;
+    private String area;
+    private String buddhistTradition;
+    private String ordinationStatus;
+    private String membershipStatus;
+}

--- a/backend/src/main/java/aranya/crm/dto/RelatedContactResponse.java
+++ b/backend/src/main/java/aranya/crm/dto/RelatedContactResponse.java
@@ -1,0 +1,19 @@
+package aranya.crm.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class RelatedContactResponse {
+    private Long id;
+    private String name;
+    private String relationshipType;
+    private String phone;
+    private String email;
+    private String addressText;
+    private boolean primary;
+    private String notes;
+}

--- a/backend/src/main/java/aranya/crm/repository/ClientRepository.java
+++ b/backend/src/main/java/aranya/crm/repository/ClientRepository.java
@@ -1,0 +1,42 @@
+package aranya.crm.repository;
+
+import aranya.crm.entity.Client;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ClientRepository extends JpaRepository<Client, Long> {
+
+    Optional<Client> findByAbbr(String abbr);
+
+    boolean existsByAbbr(String abbr);
+
+    List<Client> findAllByOrderByCreatedAtDesc();
+
+    List<Client> findByMembershipStatusIgnoreCaseOrderByCreatedAtDesc(String membershipStatus);
+
+    @Query("""
+            SELECT c FROM Client c
+            WHERE (LOWER(c.abbr) LIKE LOWER(CONCAT('%', :q, '%'))
+                OR LOWER(c.nameEn) LIKE LOWER(CONCAT('%', :q, '%'))
+                OR LOWER(c.nameChn) LIKE LOWER(CONCAT('%', :q, '%')))
+            AND LOWER(c.membershipStatus) = LOWER(:membershipStatus)
+            ORDER BY c.createdAt DESC
+            """)
+    List<Client> searchClients(
+            @Param("q") String q,
+            @Param("membershipStatus") String membershipStatus
+    );
+
+    @Query("""
+            SELECT c FROM Client c
+            WHERE LOWER(c.abbr) LIKE LOWER(CONCAT('%', :q, '%'))
+                OR LOWER(c.nameEn) LIKE LOWER(CONCAT('%', :q, '%'))
+                OR LOWER(c.nameChn) LIKE LOWER(CONCAT('%', :q, '%'))
+            ORDER BY c.createdAt DESC
+            """)
+    List<Client> searchClients(@Param("q") String q);
+}

--- a/backend/src/main/java/aranya/crm/repository/RelatedContactRepository.java
+++ b/backend/src/main/java/aranya/crm/repository/RelatedContactRepository.java
@@ -1,0 +1,18 @@
+package aranya.crm.repository;
+
+import aranya.crm.entity.RelatedContact;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface RelatedContactRepository extends JpaRepository<RelatedContact, Long> {
+
+    List<RelatedContact> findByClientIdOrderByPrimaryDescCreatedAtAsc(Long clientId);
+
+    @Modifying
+    @Query("DELETE FROM RelatedContact rc WHERE rc.client.id = :clientId")
+    int deleteByClientId(@Param("clientId") Long clientId);
+}

--- a/backend/src/main/java/aranya/crm/service/ClientService.java
+++ b/backend/src/main/java/aranya/crm/service/ClientService.java
@@ -1,0 +1,137 @@
+package aranya.crm.service;
+
+import aranya.crm.dto.ClientDetailResponse;
+import aranya.crm.dto.ClientSummaryResponse;
+import aranya.crm.dto.RelatedContactResponse;
+import aranya.crm.entity.Client;
+import aranya.crm.entity.RelatedContact;
+import aranya.crm.repository.ClientRepository;
+import aranya.crm.repository.RelatedContactRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClientService {
+
+    private final ClientRepository clientRepository;
+    private final RelatedContactRepository relatedContactRepository;
+
+    public List<ClientSummaryResponse> listClients(String q, String membershipStatus) {
+        String normalizedQuery = normalizeFilter(q);
+        String normalizedStatus = normalizeFilter(membershipStatus);
+
+        List<Client> clients;
+        if (normalizedQuery == null && normalizedStatus == null) {
+            clients = clientRepository.findAllByOrderByCreatedAtDesc();
+        } else if (normalizedQuery == null) {
+            clients = clientRepository.findByMembershipStatusIgnoreCaseOrderByCreatedAtDesc(normalizedStatus);
+        } else if (normalizedStatus == null) {
+            clients = clientRepository.searchClients(normalizedQuery);
+        } else {
+            clients = clientRepository.searchClients(normalizedQuery, normalizedStatus);
+        }
+
+        return clients.stream()
+                .map(this::toClientSummaryResponse)
+                .toList();
+    }
+
+    public ClientDetailResponse getClientDetail(Long clientId) {
+        Client client = clientRepository.findById(clientId)
+                .orElseThrow(() -> new EntityNotFoundException("Client not found: " + clientId));
+
+        List<RelatedContactResponse> relatedContacts =
+                relatedContactRepository.findByClientIdOrderByPrimaryDescCreatedAtAsc(clientId).stream()
+                        .map(this::toRelatedContactResponse)
+                        .toList();
+        return toClientDetailResponse(client, relatedContacts);
+    }
+
+    private ClientSummaryResponse toClientSummaryResponse(Client client) {
+        return ClientSummaryResponse.builder()
+                .id(client.getId())
+                .abbr(client.getAbbr())
+                .nameEn(client.getNameEn())
+                .nameChn(client.getNameChn())
+                .contact(client.getContact())
+                .preferredCommunication(client.getPreferredCommunication())
+                .preferredLanguage(client.getPreferredLanguage())
+                .area(client.getAreaDistrict())
+                .buddhistTradition(client.getBuddhistTradition())
+                .ordinationStatus(client.getOrdinationStatus())
+                .membershipStatus(client.getMembershipStatus())
+                .build();
+    }
+
+    private ClientDetailResponse toClientDetailResponse(
+            Client client,
+            List<RelatedContactResponse> relatedContacts
+    ) {
+        return ClientDetailResponse.builder()
+                .id(client.getId())
+                .abbr(client.getAbbr())
+                .nameEn(client.getNameEn())
+                .nameChn(client.getNameChn())
+                .contact(client.getContact())
+                .preferredCommunication(client.getPreferredCommunication())
+                .whatsappEnabled(client.isWhatsappEnabled())
+                .preferredLanguage(client.getPreferredLanguage())
+                .spokenLanguage(client.getSpokenLanguage())
+                .addressText(client.getAddressText())
+                .postalCode(client.getPostalCode())
+                .areaDistrict(client.getAreaDistrict())
+                .viharaType(client.getViharaType())
+                .gender(client.getGender())
+                .dateOfBirth(client.getDateOfBirth())
+                .maritalStatus(client.getMaritalStatus())
+                .nationality(client.getNationality())
+                .ethnicity(client.getEthnicity())
+                .dialectGroup(client.getDialectGroup())
+                .membershipStatus(client.getMembershipStatus())
+                .dateJoined(client.getDateJoined())
+                .membershipRemarks(client.getMembershipRemarks())
+                .buddhistTradition(client.getBuddhistTradition())
+                .ordinationStatus(client.getOrdinationStatus())
+                .wellbeingLivingConditions(client.isWellbeingLivingConditions())
+                .wellbeingMentalHealth(client.isWellbeingMentalHealth())
+                .wellbeingPhysicalHealth(client.isWellbeingPhysicalHealth())
+                .wellbeingFinancialStability(client.isWellbeingFinancialStability())
+                .wellbeingSocialSupport(client.isWellbeingSocialSupport())
+                .wellbeingLegalIssues(client.isWellbeingLegalIssues())
+                .wellbeingSpiritual(client.isWellbeingSpiritual())
+                .wellbeingRemarks(client.getWellbeingRemarks())
+                .specialNeeds(client.getSpecialNeeds())
+                .specialNeedsRemarks(client.getSpecialNeedsRemarks())
+                .nextOfKinContact(client.getNextOfKinContact())
+                .comments(client.getComments())
+                .createdAt(client.getCreatedAt())
+                .relatedContacts(relatedContacts)
+                .build();
+    }
+
+    private RelatedContactResponse toRelatedContactResponse(RelatedContact contact) {
+        return RelatedContactResponse.builder()
+                .id(contact.getId())
+                .name(contact.getName())
+                .relationshipType(contact.getRelationshipType())
+                .phone(contact.getPhone())
+                .email(contact.getEmail())
+                .addressText(contact.getAddressText())
+                .primary(contact.isPrimary())
+                .notes(contact.getNotes())
+                .build();
+    }
+
+    private String normalizeFilter(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
+}

--- a/backend/src/test/java/aranya/crm/controller/ClientControllerTest.java
+++ b/backend/src/test/java/aranya/crm/controller/ClientControllerTest.java
@@ -1,0 +1,130 @@
+package aranya.crm.controller;
+
+import aranya.crm.dto.ClientDetailResponse;
+import aranya.crm.dto.ClientSummaryResponse;
+import aranya.crm.dto.RelatedContactResponse;
+import aranya.crm.security.util.JwtUtil;
+import aranya.crm.service.ClientService;
+import aranya.crm.service.CustomUserDetailsService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ClientController.class)
+@Import(ClientControllerTest.TestSecurityConfig.class)
+class ClientControllerTest {
+
+    @TestConfiguration
+    @EnableWebSecurity
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(AbstractHttpConfigurer::disable)
+                    .authorizeHttpRequests(a -> a.anyRequest().permitAll());
+            return http.build();
+        }
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ClientService clientService;
+
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    @MockBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Test
+    @DisplayName("Authenticated user can list clients")
+    @WithMockUser(roles = "VOLUNTEER")
+    void listClients_returns200_forAuthenticatedUser() throws Exception {
+        when(clientService.listClients("tan", "ACTIVE")).thenReturn(List.of(
+                ClientSummaryResponse.builder()
+                        .id(10L)
+                        .abbr("C001")
+                        .nameEn("Tan Mei Lin")
+                        .nameChn("陈美玲")
+                        .area("Hougang")
+                        .membershipStatus("ACTIVE")
+                        .build()
+        ));
+
+        mockMvc.perform(get("/api/v1/clients")
+                        .param("q", "tan")
+                        .param("membershipStatus", "ACTIVE"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(10))
+                .andExpect(jsonPath("$[0].abbr").value("C001"))
+                .andExpect(jsonPath("$[0].area").value("Hougang"));
+    }
+
+    @Test
+    @DisplayName("Anonymous user cannot list clients")
+    void listClients_returns403_forAnonymousUser() throws Exception {
+        mockMvc.perform(get("/api/v1/clients"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Authenticated user can get client detail")
+    @WithMockUser(roles = "VOLUNTEER")
+    void getClientDetail_returns200_forAuthenticatedUser() throws Exception {
+        when(clientService.getClientDetail(10L)).thenReturn(
+                ClientDetailResponse.builder()
+                        .id(10L)
+                        .abbr("C001")
+                        .nameEn("Tan Mei Lin")
+                        .nameChn("陈美玲")
+                        .contact("91234567")
+                        .membershipStatus("ACTIVE")
+                        .createdAt(LocalDateTime.of(2026, 5, 7, 9, 30))
+                        .relatedContacts(List.of(
+                                RelatedContactResponse.builder()
+                                        .id(20L)
+                                        .name("Tan Wei")
+                                        .relationshipType("Son")
+                                        .primary(true)
+                                        .build()
+                        ))
+                        .build()
+        );
+
+        mockMvc.perform(get("/api/v1/clients/10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(10))
+                .andExpect(jsonPath("$.abbr").value("C001"))
+                .andExpect(jsonPath("$.relatedContacts[0].name").value("Tan Wei"))
+                .andExpect(jsonPath("$.cases").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("Anonymous user cannot get client detail")
+    void getClientDetail_returns403_forAnonymousUser() throws Exception {
+        mockMvc.perform(get("/api/v1/clients/10"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/backend/src/test/java/aranya/crm/repository/BusinessRepositoryTest.java
+++ b/backend/src/test/java/aranya/crm/repository/BusinessRepositoryTest.java
@@ -1,0 +1,50 @@
+package aranya.crm.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BusinessRepositoryTest {
+
+    @Test
+    @DisplayName("Core business repositories extend Spring Data JPA")
+    void coreBusinessRepositories_extendSpringDataJpa() {
+        assertThat(JpaRepository.class).isAssignableFrom(ClientRepository.class);
+        assertThat(JpaRepository.class).isAssignableFrom(RelatedContactRepository.class);
+    }
+
+    @Test
+    @DisplayName("ClientRepository exposes lookup methods needed by client workflows")
+    void clientRepository_exposesClientLookupMethods() throws Exception {
+        assertMethod(ClientRepository.class, "findByAbbr", Optional.class, String.class);
+        assertMethod(ClientRepository.class, "existsByAbbr", boolean.class, String.class);
+        assertMethod(ClientRepository.class, "findAllByOrderByCreatedAtDesc", List.class);
+        assertMethod(ClientRepository.class, "findByMembershipStatusIgnoreCaseOrderByCreatedAtDesc", List.class, String.class);
+        assertMethod(ClientRepository.class, "searchClients", List.class, String.class, String.class);
+        assertMethod(ClientRepository.class, "searchClients", List.class, String.class);
+    }
+
+    @Test
+    @DisplayName("RelatedContactRepository exposes client-scoped contact methods")
+    void relatedContactRepository_exposesClientScopedMethods() throws Exception {
+        assertMethod(RelatedContactRepository.class, "findByClientIdOrderByPrimaryDescCreatedAtAsc", List.class, Long.class);
+        assertMethod(RelatedContactRepository.class, "deleteByClientId", int.class, Long.class);
+    }
+
+    private static void assertMethod(
+            Class<?> repositoryClass,
+            String methodName,
+            Class<?> returnType,
+            Class<?>... parameterTypes
+    ) throws Exception {
+        Method method = repositoryClass.getMethod(methodName, parameterTypes);
+
+        assertThat(method.getReturnType()).isEqualTo(returnType);
+    }
+}

--- a/backend/src/test/java/aranya/crm/service/ClientServiceTest.java
+++ b/backend/src/test/java/aranya/crm/service/ClientServiceTest.java
@@ -1,0 +1,126 @@
+package aranya.crm.service;
+
+import aranya.crm.dto.ClientDetailResponse;
+import aranya.crm.dto.ClientSummaryResponse;
+import aranya.crm.entity.Client;
+import aranya.crm.entity.RelatedContact;
+import aranya.crm.repository.ClientRepository;
+import aranya.crm.repository.RelatedContactRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ClientServiceTest {
+
+    @Mock
+    private ClientRepository clientRepository;
+
+    @Mock
+    private RelatedContactRepository relatedContactRepository;
+
+    @InjectMocks
+    private ClientService clientService;
+
+    @Test
+    @DisplayName("listClients returns searchable client summaries")
+    void listClients_returnsSearchableClientSummaries() {
+        Client client = new Client();
+        client.setId(10L);
+        client.setAbbr("C001");
+        client.setNameEn("Tan Mei Lin");
+        client.setNameChn("陈美玲");
+        client.setContact("91234567");
+        client.setPreferredCommunication("WHATSAPP");
+        client.setPreferredLanguage("Mandarin");
+        client.setAreaDistrict("Hougang");
+        client.setBuddhistTradition("Mahayana");
+        client.setOrdinationStatus("Bhikkhuni");
+        client.setMembershipStatus("ACTIVE");
+        client.setCreatedAt(LocalDateTime.of(2026, 5, 7, 9, 30));
+
+        when(clientRepository.searchClients("tan", "ACTIVE")).thenReturn(List.of(client));
+
+        List<ClientSummaryResponse> response = clientService.listClients(" tan ", "ACTIVE");
+
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).getId()).isEqualTo(10L);
+        assertThat(response.get(0).getAbbr()).isEqualTo("C001");
+        assertThat(response.get(0).getNameEn()).isEqualTo("Tan Mei Lin");
+        assertThat(response.get(0).getArea()).isEqualTo("Hougang");
+        assertThat(response.get(0).getBuddhistTradition()).isEqualTo("Mahayana");
+        verify(clientRepository).searchClients("tan", "ACTIVE");
+    }
+
+    @Test
+    @DisplayName("listClients normalizes blank filters")
+    void listClients_normalizesBlankFilters() {
+        when(clientRepository.findAllByOrderByCreatedAtDesc()).thenReturn(List.of());
+
+        List<ClientSummaryResponse> response = clientService.listClients("  ", "");
+
+        assertThat(response).isEmpty();
+        verify(clientRepository).findAllByOrderByCreatedAtDesc();
+    }
+
+    @Test
+    @DisplayName("getClientDetail returns client profile with related contacts")
+    void getClientDetail_returnsClientProfileWithRelatedContacts() {
+        Client client = new Client();
+        client.setId(10L);
+        client.setAbbr("C001");
+        client.setNameEn("Tan Mei Lin");
+        client.setNameChn("陈美玲");
+        client.setContact("91234567");
+        client.setPreferredCommunication("WHATSAPP");
+        client.setWhatsappEnabled(true);
+        client.setPreferredLanguage("Mandarin");
+        client.setAddressText("123 Temple Road");
+        client.setMembershipStatus("ACTIVE");
+        client.setCreatedAt(LocalDateTime.of(2026, 5, 7, 9, 30));
+
+        RelatedContact contact = new RelatedContact();
+        contact.setId(20L);
+        contact.setName("Tan Wei");
+        contact.setRelationshipType("Son");
+        contact.setPhone("98765432");
+        contact.setEmail("wei@example.com");
+        contact.setPrimary(true);
+
+        when(clientRepository.findById(10L)).thenReturn(Optional.of(client));
+        when(relatedContactRepository.findByClientIdOrderByPrimaryDescCreatedAtAsc(10L))
+                .thenReturn(List.of(contact));
+
+        ClientDetailResponse response = clientService.getClientDetail(10L);
+
+        assertThat(response.getId()).isEqualTo(10L);
+        assertThat(response.getAbbr()).isEqualTo("C001");
+        assertThat(response.getNameEn()).isEqualTo("Tan Mei Lin");
+        assertThat(response.getRelatedContacts()).hasSize(1);
+        assertThat(response.getRelatedContacts().get(0).getName()).isEqualTo("Tan Wei");
+        verify(relatedContactRepository).findByClientIdOrderByPrimaryDescCreatedAtAsc(10L);
+    }
+
+    @Test
+    @DisplayName("getClientDetail throws when client does not exist")
+    void getClientDetail_throwsWhenClientDoesNotExist() {
+        when(clientRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> clientService.getClientDetail(99L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("Client not found: 99");
+    }
+}

--- a/docs/current-module-status.md
+++ b/docs/current-module-status.md
@@ -1,0 +1,304 @@
+# Current Module Status / 当前模块状态
+
+This document summarizes the current status of two completed areas:
+
+本文总结目前已经完成的两部分工作：
+
+1. Roles authentication / capability manifest.
+2. Client list/detail read flow.
+
+---
+
+## 1. Roles Authentication / Capability Manifest
+
+## 1. 角色认证 / 能力清单模块
+
+### Core Idea / 核心设计
+
+The system separates permission decisions from UI rendering.
+
+系统把“权限判断”和“前端渲染”分开。
+
+The backend decides what the current user can access or do. The frontend decides how the allowed UI should look.
+
+后端负责判断当前用户能访问什么、能执行什么；前端负责决定这些允许显示的内容怎么展示。
+
+The frontend does not receive role names such as `VOLUNTEER`, `SOCIAL_WORKER`, or `MANAGER`. It only receives a capability manifest:
+
+前端不会收到 `VOLUNTEER`、`SOCIAL_WORKER`、`MANAGER` 这类角色名，只会收到后端返回的能力清单：
+
+```json
+{
+  "routes": [],
+  "features": [],
+  "widgets": []
+}
+```
+
+### Manifest Design / 清单设计
+
+The capability manifest comes from the role-permission overview. The human-readable permission overview defines what each role can do. That design is then translated into capability ids, and those capability ids are stored in the database.
+
+能力清单来源于权限总览。权限总览先用人能读懂的方式定义每个角色能做什么；然后这些权限被翻译成 capability id；最后 capability id 被迁移到数据库中。
+
+Current design flow:
+
+当前设计链路：
+
+```text
+Role-Permission-Overview
+        ↓
+Capability sitemap
+        ↓
+permission table
+        ↓
+role_permission table
+        ↓
+/api/v1/ui/manifest
+        ↓
+Frontend canRoute / canFeature / canWidget
+```
+
+The database now stores the permission model instead of hardcoding role checks in the frontend. The backend reads the current user's role permissions and returns only the allowed capability ids.
+
+现在权限模型已经从前端硬编码角色判断，迁移到了数据库。后端根据当前用户的角色权限查询数据库，然后只返回允许的 capability id。
+
+The manifest is intentionally small. It only answers what the user can access or do. It does not describe how the UI should look.
+
+这个清单刻意保持很小。它只回答“用户能看什么、能做什么”，不描述 UI 应该怎么长。
+
+### Responsibility Split / 前后端分工
+
+Frontend owns:
+
+前端负责：
+
+- Components / 组件
+- Layout / 页面布局
+- Static labels / 静态文案，例如日期、姓名、状态、按钮文案
+- Table column display / 表格字段展示方式
+- Interaction and local rendering / 交互体验和局部渲染
+- Page transitions / 页面切换
+- Figma UI structure / Figma 对应的 UI 结构
+
+Backend owns:
+
+后端负责：
+
+- Authenticate the current user / 认证当前是谁
+- Decide accessible pages, features, and actions / 判断能访问哪些页面、功能和操作
+- Return dynamic data / 返回动态数据
+- Execute business operations / 执行业务操作
+- Enforce final permissions / 做最终权限校验
+
+### How It Works / 运行方式
+
+After login, the frontend calls:
+
+登录后，前端会调用：
+
+```http
+GET /api/v1/users/me
+GET /api/v1/ui/manifest
+```
+
+`/users/me` confirms the current authenticated profile.
+
+`/users/me` 用来确认当前登录用户的基础信息。
+
+`/ui/manifest` returns what the user can access:
+
+`/ui/manifest` 返回当前用户能访问和能操作的能力清单：
+
+```text
+routes   -> page access and sidebar visibility
+features -> page actions, buttons, and operations
+widgets  -> dashboard widgets
+```
+
+```text
+routes   -> 页面访问和侧边栏入口
+features -> 页面里的操作、按钮、动作
+widgets  -> Dashboard 小组件
+```
+
+The frontend then checks:
+
+前端之后只检查：
+
+```ts
+canRoute('cases.list')
+canFeature('reports.create')
+canWidget('dashboard.myReports')
+```
+
+The backend still needs to enforce permissions on real business APIs. The manifest only helps the frontend render the correct UI.
+
+后端业务 API 仍然需要做最终权限校验。manifest 只是帮助前端渲染正确的 UI。
+
+### Current Status / 当前状态
+
+Completed:
+
+已完成：
+
+- JWT no longer carries roles.
+- JWT 不再携带 roles。
+- `/users/me` no longer returns roles.
+- `/users/me` 不再返回 roles。
+- `/ui/manifest` returns only capability ids.
+- `/ui/manifest` 只返回能力 id。
+- Frontend no longer checks role names directly.
+- 前端不再直接判断角色名。
+- Sidebar and route access are capability-driven.
+- 侧边栏和路由访问由 capability 控制。
+- Dashboard has started using feature/widget capabilities.
+- Dashboard 已开始使用 feature/widget capability。
+- Volunteer no longer has any `clients.*` or `cases.*` capability.
+- Volunteer 不再拥有任何 `clients.*` 或 `cases.*` capability。
+- Social Worker cannot delete reports or close cases.
+- Social Worker 不能删除报告，也不能关闭 case。
+- Manager can delete reports and close cases, but cannot edit reports.
+- Manager 可以删除报告、关闭 case，但不能编辑报告。
+
+Not fully completed:
+
+尚未完全完成：
+
+- Reports, Cases, and Users pages are not fully implemented yet.
+- Reports、Cases、Users 页面还没有完整实现。
+- Some business APIs still need final permission enforcement as they become real.
+- 一些业务 API 后续实现时还需要补最终权限校验。
+- Full Figma-based UI implementation is for the next frontend phase.
+- 完整 Figma UI 复刻属于下一阶段前端工作。
+
+---
+
+## 2. Client Read Flow
+
+## 2. Client 读取链路
+
+### Core Idea / 核心设计
+
+The Client module currently has a minimum working read loop for list and detail pages.
+
+Client 模块目前已经完成列表页和详情页的最小读取闭环。
+
+The goal is to prove that real client data can flow from PostgreSQL to the frontend pages.
+
+目标是验证真实 client 数据可以从 PostgreSQL 一路传到前端页面。
+
+The current backend entity and table modeling is also in place. The main domain entities have matching database tables, so the data model is ready for normal repository/service/API development.
+
+目前后端的 Entity 和数据库表建模也已经完善，主要业务实体和数据表基本一一对应，因此后续可以按正常的 Repository / Service / API 链路继续开发。
+
+### Current API Scope / 当前 API 范围
+
+Backend read APIs:
+
+后端读取接口：
+
+```http
+GET /api/v1/clients
+GET /api/v1/clients/{id}
+```
+
+`GET /api/v1/clients` is used by the Client list page.
+
+`GET /api/v1/clients` 给 Client list 页面使用。
+
+`GET /api/v1/clients/{id}` is used by the Client detail page.
+
+`GET /api/v1/clients/{id}` 给 Client detail 页面使用。
+
+### Data Flow / 数据链路
+
+The current minimum loop is:
+
+当前最小闭环是：
+
+```text
+PostgreSQL client / related_contact tables
+        ↓
+JPA Entity
+        ↓
+Repository
+        ↓
+Service
+        ↓
+Controller API
+        ↓
+frontend client API wrapper
+        ↓
+React Query hooks
+        ↓
+Client list / detail pages
+```
+
+### Current Status / 当前状态
+
+Completed:
+
+已完成：
+
+- Backend can read client list data.
+- 后端可以读取 client 列表数据。
+- Backend can read client detail data.
+- 后端可以读取 client 详情数据。
+- Detail data can include related contacts.
+- 详情数据可以包含 related contacts。
+- Frontend calls real Client APIs.
+- 前端已经接入真实 Client API。
+- Client list page displays real API data.
+- Client list 页面展示真实接口数据。
+- Client detail page displays real API data.
+- Client detail 页面展示真实接口数据。
+
+Not included yet:
+
+尚未包含：
+
+- Client create.
+- 新建 Client。
+- Client edit.
+- 编辑 Client。
+- Client delete.
+- 删除 Client。
+- Document management.
+- 文档管理。
+- GCS / Firebase Storage integration.
+- GCS / Firebase Storage 集成。
+
+---
+
+## 3. How These Two Parts Work Together
+
+## 3. 两部分如何配合
+
+The capability manifest decides whether the user can enter the Client pages or see related actions.
+
+Capability manifest 决定当前用户能不能进入 Client 页面、能不能看到相关操作。
+
+The Client APIs provide the real business data after access is allowed.
+
+Client API 在用户被允许访问后，负责提供真实业务数据。
+
+In short:
+
+简单说：
+
+```text
+Capability manifest = what the user is allowed to see or do
+Client APIs = actual client data
+Frontend UI = how the allowed data and actions are displayed
+```
+
+```text
+Capability manifest = 用户能看什么、能做什么
+Client APIs = 真实 client 数据
+Frontend UI = 这些数据和操作如何展示
+```
+
+This keeps the system maintainable: permissions can change through backend capability mapping, while UI layout and Figma structure stay in the frontend.
+
+这样系统会更容易维护：权限变化主要通过后端 capability 映射调整，而 UI 布局和 Figma 结构继续留在前端。

--- a/frontend/src/features/clients/api/client.api.ts
+++ b/frontend/src/features/clients/api/client.api.ts
@@ -2,6 +2,67 @@ import { http } from '../../../shared/api'
 import { clientMockData } from '../../../mocks/client.mock'
 import type { Client } from '../types'
 
+type BackendClientSummary = {
+  id: number | string
+  abbr?: string | null
+  nameEn?: string | null
+  nameChn?: string | null
+  contact?: string | null
+  preferredCommunication?: string | null
+  preferredLanguage?: string | null
+  area?: string | null
+  buddhistTradition?: string | null
+  ordinationStatus?: string | null
+  membershipStatus?: string | null
+}
+
+type BackendClientDetail = BackendClientSummary & {
+  whatsappEnabled?: boolean | null
+  spokenLanguage?: string | null
+  addressText?: string | null
+  postalCode?: string | null
+  areaDistrict?: string | null
+  viharaType?: string | null
+  gender?: string | null
+  dateOfBirth?: string | null
+  maritalStatus?: string | null
+  nationality?: string | null
+  ethnicity?: string | null
+  dialectGroup?: string | null
+  dateJoined?: string | null
+  membershipRemarks?: string | null
+  wellbeingLivingConditions?: boolean | null
+  wellbeingMentalHealth?: boolean | null
+  wellbeingPhysicalHealth?: boolean | null
+  wellbeingFinancialStability?: boolean | null
+  wellbeingSocialSupport?: boolean | null
+  wellbeingLegalIssues?: boolean | null
+  wellbeingSpiritual?: boolean | null
+  wellbeingRemarks?: string | null
+  specialNeeds?: string | null
+  specialNeedsRemarks?: string | null
+  nextOfKinContact?: string | null
+  comments?: string | null
+}
+
+const emptyWellbeing = {
+  physicalHealth: false,
+  mentalHealth: false,
+  socialSupport: false,
+  financialStability: false,
+  livingConditions: false,
+  spiritualWellbeing: false,
+  legalIssues: false,
+  substanceUse: false,
+}
+
+const emptySpecialNeeds = {
+  physical: false,
+  hearing: false,
+  visual: false,
+  intellectual: false,
+}
+
 function getDataMode(): 'mock' | 'api' | 'auto' {
   const mode = (import.meta.env.VITE_DATA_MODE ?? 'auto').toLowerCase()
   if (mode === 'mock' || mode === 'api') return mode
@@ -13,8 +74,8 @@ export async function fetchClients(): Promise<Client[]> {
   if (mode === 'mock') return clientMockData
 
   try {
-    const res = await http.get<Client[]>('/v1/clients')
-    return res.data
+    const res = await http.get<BackendClientSummary[]>('/v1/clients')
+    return res.data.map(mapBackendClient)
   } catch {
     if (mode === 'auto') return clientMockData
     throw new Error('Failed to fetch clients')
@@ -26,8 +87,8 @@ export async function fetchClientById(id: string): Promise<Client | undefined> {
   if (mode === 'mock') return clientMockData.find((c) => c.id === id)
 
   try {
-    const res = await http.get<Client>(`/v1/clients/${id}`)
-    return res.data
+    const res = await http.get<BackendClientDetail>(`/v1/clients/${id}`)
+    return mapBackendClient(res.data)
   } catch {
     if (mode === 'auto') return clientMockData.find((c) => c.id === id)
     throw new Error('Failed to fetch client')
@@ -78,4 +139,146 @@ export async function updateClient(id: string, data: Partial<Client>): Promise<C
     }
     throw new Error('Failed to update client')
   }
+}
+
+function mapBackendClient(source: BackendClientDetail): Client {
+  const dateOfBirth = text(source.dateOfBirth)
+  const dateOrdination = ''
+
+  return {
+    id: String(source.id),
+    abbr: text(source.abbr),
+    nameEn: text(source.nameEn),
+    nameChn: text(source.nameChn),
+    nricNameEn: '',
+    nricNameChn: '',
+    nricNo: '',
+    sex: mapSex(source.gender),
+    dateOfBirth,
+    age: calculateYearsSince(dateOfBirth),
+    maritalStatus: mapMaritalStatus(source.maritalStatus),
+    nationality: text(source.nationality),
+    ethnicity: text(source.ethnicity),
+    dialectGroup: text(source.dialectGroup),
+    contact: text(source.contact),
+    nextOfKin: text(source.nextOfKinContact),
+    preferredCommunication: mapPreferredCommunication(source.preferredCommunication),
+    ableToUseWhatsApp: Boolean(source.whatsappEnabled),
+    preferredLanguage: text(source.preferredLanguage),
+    spokenLanguage: text(source.spokenLanguage),
+    address: text(source.addressText),
+    postalCode: text(source.postalCode),
+    viharaType: text(source.viharaType),
+    area: text(source.areaDistrict ?? source.area),
+    membershipStatus: mapMembershipStatus(source.membershipStatus),
+    dateJoined: text(source.dateJoined),
+    membershipRemarks: text(source.membershipRemarks),
+    buddhistTradition: mapBuddhistTradition(source.buddhistTradition),
+    ordinationStatus: mapOrdinationStatus(source.ordinationStatus),
+    dateTonsure: '',
+    countryTonsure: '',
+    placeTonsure: '',
+    dateOrdination,
+    countryOrdination: '',
+    placeOrdination: '',
+    ordinationYears: calculateYearsSince(dateOrdination),
+    ordinationCertificate: 'Incomplete',
+    dateVerification: '',
+    wellbeingIssues: {
+      ...emptyWellbeing,
+      physicalHealth: Boolean(source.wellbeingPhysicalHealth),
+      mentalHealth: Boolean(source.wellbeingMentalHealth),
+      socialSupport: Boolean(source.wellbeingSocialSupport),
+      financialStability: Boolean(source.wellbeingFinancialStability),
+      livingConditions: Boolean(source.wellbeingLivingConditions),
+      spiritualWellbeing: Boolean(source.wellbeingSpiritual),
+      legalIssues: Boolean(source.wellbeingLegalIssues),
+    },
+    wellbeingRemarks: text(source.wellbeingRemarks),
+    specialNeeds: mapSpecialNeeds(source.specialNeeds),
+    specialNeedsRemarks: text(source.specialNeedsRemarks),
+    bankTransfer: false,
+    payNow: false,
+    comments: text(source.comments),
+  }
+}
+
+function text(value: string | number | null | undefined): string {
+  return value === null || value === undefined ? '' : String(value)
+}
+
+function normalizeEnum(value: string | null | undefined): string {
+  return text(value).trim().replaceAll('_', ' ').toLowerCase()
+}
+
+function mapMembershipStatus(value: string | null | undefined): Client['membershipStatus'] {
+  const normalized = normalizeEnum(value)
+  if (normalized === 'inactive') return 'Inactive'
+  if (normalized === 'discharged') return 'Discharged'
+  if (normalized === 'withdrawn') return 'Withdrawn'
+  if (normalized === 'deceased') return 'Deceased'
+  return 'Active'
+}
+
+function mapPreferredCommunication(value: string | null | undefined): Client['preferredCommunication'] {
+  const normalized = normalizeEnum(value)
+  if (normalized.includes('audio')) return 'WhatsApp Audio'
+  if (normalized.includes('whatsapp')) return 'WhatsApp Msg'
+  if (normalized.includes('home')) return 'Home Visit'
+  return 'Phone Call'
+}
+
+function mapSex(value: string | null | undefined): Client['sex'] {
+  const normalized = normalizeEnum(value)
+  return normalized.startsWith('f') ? 'Female' : 'Male'
+}
+
+function mapMaritalStatus(value: string | null | undefined): Client['maritalStatus'] {
+  const normalized = normalizeEnum(value)
+  if (normalized === 'married') return 'Married'
+  if (normalized === 'divorced') return 'Divorced'
+  if (normalized === 'separated') return 'Separated'
+  if (normalized === 'widowed') return 'Widowed'
+  return 'Never married'
+}
+
+function mapBuddhistTradition(value: string | null | undefined): Client['buddhistTradition'] {
+  const normalized = normalizeEnum(value)
+  if (normalized === 'theravada') return 'Theravada'
+  if (normalized === 'vajrayana') return 'Vajrayana'
+  return 'Mahayana'
+}
+
+function mapOrdinationStatus(value: string | null | undefined): Client['ordinationStatus'] {
+  const normalized = normalizeEnum(value)
+  if (normalized === 'bhikkhuni') return 'Bhikkhuni'
+  if (normalized === 'samanera') return 'Samanera'
+  if (normalized === 'sikkhamana') return 'Sikkhamana'
+  if (normalized === 'sayalay') return 'Sayalay'
+  return 'Bhikkhu'
+}
+
+function mapSpecialNeeds(value: string | null | undefined): Client['specialNeeds'] {
+  const normalized = normalizeEnum(value)
+  return {
+    ...emptySpecialNeeds,
+    physical: normalized.includes('physical'),
+    hearing: normalized.includes('hearing'),
+    visual: normalized.includes('visual'),
+    intellectual: normalized.includes('intellectual'),
+  }
+}
+
+function calculateYearsSince(date: string): number {
+  if (!date) return 0
+  const parsed = new Date(date)
+  if (Number.isNaN(parsed.getTime())) return 0
+
+  const now = new Date()
+  let years = now.getFullYear() - parsed.getFullYear()
+  const hasNotReachedAnniversary =
+    now.getMonth() < parsed.getMonth() ||
+    (now.getMonth() === parsed.getMonth() && now.getDate() < parsed.getDate())
+  if (hasNotReachedAnniversary) years -= 1
+  return Math.max(years, 0)
 }


### PR DESCRIPTION
feat(client): add backend client read API and connect frontend pages

Add the minimum read-only Client workflow from database to UI.

Backend:
- Add ClientRepository and RelatedContactRepository for client profile lookup.
- Add ClientService to map Client and RelatedContact entities into response DTOs.
- Add ClientController with list and detail endpoints:
  - GET /api/v1/clients
  - GET /api/v1/clients/{id}
- Add ClientSummaryResponse, ClientDetailResponse, and RelatedContactResponse DTOs.
- Support client list filtering by search query and membership status.
- Keep Client detail scoped to client profile and related contacts only.

Frontend:
- Update client API service to call real backend Client endpoints.
- Map backend response fields into the existing frontend Client type.
- Preserve mock fallback behavior for local development.
- Keep Client list and detail pages using the existing React Query hooks.

Tests:
- Add/update focused tests for Client service, controller, and repository contracts.
