### PR TITLE
feat: 实现 Dashboard 后端动态数据接口

### DIFF
--- a/backend/src/main/java/aranya/crm/controller/DashboardController.java
+++ b/backend/src/main/java/aranya/crm/controller/DashboardController.java
@@ -1,71 +1,25 @@
 package aranya.crm.controller;
 
 import aranya.crm.dto.response.DashboardResponse;
+import aranya.crm.service.DashboardService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
-/*TODO:
-*  目前只是临时模拟数据,还需要修改
-* */
 @RestController
-@RequestMapping("/api/dashboard")
+@RequestMapping("/api/v1/dashboard")
+@RequiredArgsConstructor
+@PreAuthorize("isAuthenticated()")
 public class DashboardController {
 
-    @GetMapping
-    public ResponseEntity<DashboardResponse> getDashboard() {
-        return ResponseEntity.ok(
-                DashboardResponse.builder()
-                        .activeCases(List.of(
-                                DashboardResponse.ActiveCase.builder()
-                                        .id("case-001")
-                                        .title(text("紧急住房支持", "Emergency Housing Support"))
-                                        .client(text("释慧明", "Monastic Sumedho"))
-                                        .status(text("审核中", "In Review"))
-                                        .build(),
-                                DashboardResponse.ActiveCase.builder()
-                                        .id("case-002")
-                                        .title(text("医疗补助申请", "Medical Assistance Application"))
-                                        .client(text("释妙音", "Monastic Dhamma"))
-                                        .status(text("待跟进", "Pending Follow-up"))
-                                        .build()
-                        ))
-                        .attentionCases(List.of(
-                                DashboardResponse.AttentionCase.builder()
-                                        .id("attention-001")
-                                        .client(text("释妙音", "Monastic Dhamma"))
-                                        .reason(text("等待志愿者分配", "Awaiting volunteer assignment"))
-                                        .daysOpen(5)
-                                        .build(),
-                                DashboardResponse.AttentionCase.builder()
-                                        .id("attention-002")
-                                        .client(text("释法住", "Monastic Saddha"))
-                                        .reason(text("补充材料待提交", "Supporting documents pending"))
-                                        .daysOpen(3)
-                                        .build()
-                        ))
-                        .upcomingAppointments(List.of(
-                                DashboardResponse.UpcomingAppointment.builder()
-                                        .id("appt-001")
-                                        .startsAt("2026-04-10T10:00:00+08:00")
-                                        .client(text("释慧明", "Monastic Sumedho"))
-                                        .purpose(text("家访评估", "Home Visit Assessment"))
-                                        .build(),
-                                DashboardResponse.UpcomingAppointment.builder()
-                                        .id("appt-002")
-                                        .startsAt("2026-04-11T14:30:00+08:00")
-                                        .client(text("释妙音", "Monastic Dhamma"))
-                                        .purpose(text("个案跟进", "Case Follow-up"))
-                                        .build()
-                        ))
-                        .build()
-        );
-    }
+    private final DashboardService dashboardService;
 
-    private DashboardResponse.LocalizedText text(String zh, String en) {
-        return new DashboardResponse.LocalizedText(zh, en);
+    @GetMapping
+    public ResponseEntity<DashboardResponse> getDashboard(Authentication authentication) {
+        return ResponseEntity.ok(dashboardService.getDashboard(authentication));
     }
 }

--- a/backend/src/main/java/aranya/crm/dto/response/DashboardResponse.java
+++ b/backend/src/main/java/aranya/crm/dto/response/DashboardResponse.java
@@ -1,52 +1,92 @@
 package aranya.crm.dto.response;
 
-import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
-/*TODO:
-*  目前还是临时数据,还需要修改*/
 @Data
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class DashboardResponse {
-    private List<ActiveCase> activeCases;
-    private List<AttentionCase> attentionCases;
-    private List<UpcomingAppointment> upcomingAppointments;
+    private DesignSystem designSystem;
+    private Screen screen;
+    private List<Section> sections;
+    private Metadata metadata;
 
     @Data
     @Builder
-    @AllArgsConstructor
-    public static class LocalizedText {
-        private String zh;
-        private String en;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class DesignSystem {
+        private String name;
+        private String version;
     }
 
     @Data
     @Builder
-    public static class ActiveCase {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Screen {
         private String id;
-        private LocalizedText title;
-        private LocalizedText client;
-        private LocalizedText status;
+        private String version;
     }
 
     @Data
     @Builder
-    public static class AttentionCase {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Section {
         private String id;
-        private LocalizedText client;
-        private LocalizedText reason;
-        private int daysOpen;
+        private List<Stat> stats;
+        private List<Item> items;
+        private List<Action> actions;
     }
 
     @Data
     @Builder
-    public static class UpcomingAppointment {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Stat {
         private String id;
-        private String startsAt;
-        private LocalizedText client;
-        private LocalizedText purpose;
+        private String value;
+    }
+
+    @Data
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Item {
+        private String id;
+        private String clientId;
+        private String clientNameChn;
+        private String clientNameEn;
+        private String caseCode;
+        private String statusCode;
+        private String colorCode;
+        private String openedAt;
+        private String reportType;
+        private String dateOfVisit;
+        private String createdAt;
+        private String createdById;
+        private String createdByName;
+    }
+
+    @Data
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Action {
+        private String id;
+        private String targetId;
+    }
+
+    @Data
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Metadata {
+        private String generatedAt;
+
+        public static Metadata now() {
+            return Metadata.builder()
+                    .generatedAt(OffsetDateTime.now().toString())
+                    .build();
+        }
     }
 }

--- a/backend/src/main/java/aranya/crm/entity/ClientCase.java
+++ b/backend/src/main/java/aranya/crm/entity/ClientCase.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @Entity
-@Table(name = "case")
+@Table(name = "\"case\"")
 public class ClientCase {
 
     @Id

--- a/backend/src/main/java/aranya/crm/repository/ClientRepository.java
+++ b/backend/src/main/java/aranya/crm/repository/ClientRepository.java
@@ -18,6 +18,8 @@ public interface ClientRepository extends JpaRepository<Client, Long> {
 
     List<Client> findByMembershipStatusIgnoreCaseOrderByCreatedAtDesc(String membershipStatus);
 
+    long countByMembershipStatusIgnoreCase(String membershipStatus);
+
     @Query("""
             SELECT c FROM Client c
             WHERE (LOWER(c.abbr) LIKE LOWER(CONCAT('%', :q, '%'))

--- a/backend/src/main/java/aranya/crm/repository/VisitReportRepository.java
+++ b/backend/src/main/java/aranya/crm/repository/VisitReportRepository.java
@@ -1,0 +1,19 @@
+package aranya.crm.repository;
+
+import aranya.crm.entity.VisitReport;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface VisitReportRepository extends JpaRepository<VisitReport, Long> {
+
+    long countByCreatedById(Long createdById);
+
+    @EntityGraph(attributePaths = {"client", "createdBy"})
+    List<VisitReport> findByCreatedByIdOrderByCreatedAtDescIdDesc(Long createdById, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"client", "createdBy"})
+    List<VisitReport> findAllByOrderByCreatedAtDescIdDesc(Pageable pageable);
+}

--- a/backend/src/main/java/aranya/crm/service/DashboardService.java
+++ b/backend/src/main/java/aranya/crm/service/DashboardService.java
@@ -1,0 +1,191 @@
+package aranya.crm.service;
+
+import aranya.crm.dto.response.DashboardResponse;
+import aranya.crm.entity.Client;
+import aranya.crm.entity.ClientCase;
+import aranya.crm.entity.User;
+import aranya.crm.entity.VisitReport;
+import aranya.crm.repository.ClientRepository;
+import aranya.crm.repository.VisitReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DashboardService {
+
+    private static final int DASHBOARD_LIST_LIMIT = 5;
+    private static final String ACTIVE_MEMBERSHIP_STATUS = "ACTIVE";
+
+    private final ClientRepository clientRepository;
+    private final CaseService caseService;
+    private final VisitReportRepository visitReportRepository;
+
+    public DashboardResponse getDashboard(Authentication authentication) {
+        User currentUser = authentication != null && authentication.getPrincipal() instanceof User user
+                ? user
+                : null;
+        Set<String> roles = roleNames(authentication);
+
+        List<DashboardResponse.Section> sections = new ArrayList<>();
+        if (roles.contains("VOLUNTEER") && currentUser != null) {
+            sections.add(volunteerReportStats(currentUser.getId()));
+            sections.add(volunteerRecentReports(currentUser.getId()));
+            sections.add(volunteerQuickActions());
+        }
+        if (roles.contains("SOCIAL_WORKER") || roles.contains("MANAGER")) {
+            sections.add(socialWorkerStats());
+            sections.add(socialWorkerRecentCases());
+            sections.add(socialWorkerRecentReports());
+            sections.add(socialWorkerQuickActions());
+        }
+
+        return DashboardResponse.builder()
+                .designSystem(DashboardResponse.DesignSystem.builder()
+                        .name("aranya-crm-dashboard")
+                        .version("1.0")
+                        .build())
+                .screen(DashboardResponse.Screen.builder()
+                        .id("dashboard")
+                        .version("2026-05-13")
+                        .build())
+                .sections(sections)
+                .metadata(DashboardResponse.Metadata.now())
+                .build();
+    }
+
+    private DashboardResponse.Section volunteerReportStats(Long currentUserId) {
+        return DashboardResponse.Section.builder()
+                .id("volunteer.report_stats")
+                .stats(List.of(stat("myReportCount", visitReportRepository.countByCreatedById(currentUserId))))
+                .build();
+    }
+
+    private DashboardResponse.Section volunteerRecentReports(Long currentUserId) {
+        List<DashboardResponse.Item> items = visitReportRepository
+                .findByCreatedByIdOrderByCreatedAtDescIdDesc(currentUserId, PageRequest.of(0, DASHBOARD_LIST_LIMIT))
+                .stream()
+                .map(this::toReportItem)
+                .toList();
+
+        return DashboardResponse.Section.builder()
+                .id("volunteer.my_recent_reports")
+                .items(items)
+                .build();
+    }
+
+    private DashboardResponse.Section volunteerQuickActions() {
+        return DashboardResponse.Section.builder()
+                .id("volunteer.quick_actions")
+                .actions(List.of(action("submit_report")))
+                .build();
+    }
+
+    private DashboardResponse.Section socialWorkerStats() {
+        return DashboardResponse.Section.builder()
+                .id("sw.stats")
+                .stats(List.of(
+                        stat("activeMonastics", clientRepository.countByMembershipStatusIgnoreCase(ACTIVE_MEMBERSHIP_STATUS)),
+                        stat("openCases", caseService.countActiveCases()),
+                        stat("urgentCases", caseService.countUrgentCases()),
+                        stat("pendingReports", 0L)
+                ))
+                .build();
+    }
+
+    private DashboardResponse.Section socialWorkerRecentCases() {
+        List<DashboardResponse.Item> items = caseService.getActiveCases(DASHBOARD_LIST_LIMIT)
+                .stream()
+                .map(this::toCaseItem)
+                .toList();
+
+        return DashboardResponse.Section.builder()
+                .id("sw.recent_cases")
+                .items(items)
+                .build();
+    }
+
+    private DashboardResponse.Section socialWorkerRecentReports() {
+        List<DashboardResponse.Item> items = visitReportRepository
+                .findAllByOrderByCreatedAtDescIdDesc(PageRequest.of(0, DASHBOARD_LIST_LIMIT))
+                .stream()
+                .map(this::toReportItem)
+                .toList();
+
+        return DashboardResponse.Section.builder()
+                .id("sw.recent_reports")
+                .items(items)
+                .build();
+    }
+
+    private DashboardResponse.Section socialWorkerQuickActions() {
+        return DashboardResponse.Section.builder()
+                .id("sw.quick_actions")
+                .actions(List.of(action("new_case"), action("add_client")))
+                .build();
+    }
+
+    private DashboardResponse.Item toCaseItem(ClientCase clientCase) {
+        Client client = clientCase.getClient();
+        return DashboardResponse.Item.builder()
+                .id(String.valueOf(clientCase.getId()))
+                .clientId(client != null ? String.valueOf(client.getId()) : null)
+                .clientNameChn(client != null ? client.getNameChn() : null)
+                .clientNameEn(client != null ? client.getNameEn() : null)
+                .caseCode(clientCase.getCaseCode())
+                .statusCode(clientCase.getStatus())
+                .colorCode(clientCase.getColorCode())
+                .openedAt(clientCase.getOpenedAt() != null ? clientCase.getOpenedAt().toString() : null)
+                .build();
+    }
+
+    private DashboardResponse.Item toReportItem(VisitReport report) {
+        Client client = report.getClient();
+        User createdBy = report.getCreatedBy();
+        return DashboardResponse.Item.builder()
+                .id(String.valueOf(report.getId()))
+                .clientId(client != null ? String.valueOf(client.getId()) : null)
+                .clientNameChn(client != null ? client.getNameChn() : null)
+                .clientNameEn(client != null ? client.getNameEn() : null)
+                .reportType(report.getTypeOfVisit())
+                .dateOfVisit(report.getDateOfVisit() != null ? report.getDateOfVisit().toString() : null)
+                .createdAt(report.getCreatedAt() != null ? report.getCreatedAt().toString() : null)
+                .createdById(createdBy != null ? String.valueOf(createdBy.getId()) : null)
+                .createdByName(createdBy != null ? createdBy.getFullName() : null)
+                .build();
+    }
+
+    private DashboardResponse.Stat stat(String id, long value) {
+        return DashboardResponse.Stat.builder()
+                .id(id)
+                .value(String.valueOf(value))
+                .build();
+    }
+
+    private DashboardResponse.Action action(String id) {
+        return DashboardResponse.Action.builder()
+                .id(id)
+                .build();
+    }
+
+    private Set<String> roleNames(Authentication authentication) {
+        if (authentication == null) {
+            return Set.of();
+        }
+        return authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .filter(authority -> authority.startsWith("ROLE_"))
+                .map(authority -> authority.substring("ROLE_".length()))
+                .collect(Collectors.toSet());
+    }
+}

--- a/backend/src/test/java/aranya/crm/controller/DashboardControllerTest.java
+++ b/backend/src/test/java/aranya/crm/controller/DashboardControllerTest.java
@@ -1,0 +1,99 @@
+package aranya.crm.controller;
+
+import aranya.crm.dto.response.DashboardResponse;
+import aranya.crm.service.DashboardService;
+import aranya.crm.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = DashboardController.class)
+@Import(DashboardControllerTest.TestSecurityConfig.class)
+class DashboardControllerTest {
+
+    @TestConfiguration
+    @EnableWebSecurity
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(AbstractHttpConfigurer::disable)
+                    .authorizeHttpRequests(a -> a.anyRequest().permitAll());
+            return http.build();
+        }
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private DashboardService dashboardService;
+
+    @MockitoBean
+    private UserService userService;
+
+    @Test
+    @DisplayName("GET /api/v1/dashboard returns dashboard data blocks")
+    @WithMockUser(roles = "SOCIAL_WORKER")
+    void getDashboard_returnsDashboardDataBlocks() throws Exception {
+        when(dashboardService.getDashboard(any())).thenReturn(
+                DashboardResponse.builder()
+                        .designSystem(DashboardResponse.DesignSystem.builder()
+                                .name("aranya-crm-dashboard")
+                                .version("1.0")
+                                .build())
+                        .screen(DashboardResponse.Screen.builder()
+                                .id("dashboard")
+                                .version("2026-05-13")
+                                .build())
+                        .sections(List.of(
+                                DashboardResponse.Section.builder()
+                                        .id("sw.stats")
+                                        .stats(List.of(DashboardResponse.Stat.builder()
+                                                .id("activeMonastics")
+                                                .value("3")
+                                                .build()))
+                                        .build()
+                        ))
+                        .metadata(DashboardResponse.Metadata.now())
+                        .build()
+        );
+
+        mockMvc.perform(get("/api/v1/dashboard"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.screen.id").value("dashboard"))
+                .andExpect(jsonPath("$.sections[0].id").value("sw.stats"))
+                .andExpect(jsonPath("$.sections[0].stats[0].id").value("activeMonastics"))
+                .andExpect(jsonPath("$.sections[0].stats[0].value").value("3"))
+                .andExpect(jsonPath("$.sections[0].type").doesNotExist())
+                .andExpect(jsonPath("$.sections[0].title").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("Old dashboard route is not exposed")
+    @WithMockUser(roles = "SOCIAL_WORKER")
+    void oldDashboardRoute_isNotExposed() throws Exception {
+        mockMvc.perform(get("/api/dashboard"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/backend/src/test/java/aranya/crm/entity/BusinessEntityMappingTest.java
+++ b/backend/src/test/java/aranya/crm/entity/BusinessEntityMappingTest.java
@@ -20,7 +20,7 @@ class BusinessEntityMappingTest {
                 Map.entry(Invitation.class, "invitation"),
                 Map.entry(EmailNotificationLog.class, "email_notification_log"),
                 Map.entry(RelatedContact.class, "related_contact"),
-                Map.entry(ClientCase.class, "case"),
+                Map.entry(ClientCase.class, "\"case\""),
                 Map.entry(ServiceCategory.class, "service_category"),
                 Map.entry(ServiceType.class, "service_type"),
                 Map.entry(CaseAssignment.class, "case_assignment"),

--- a/backend/src/test/java/aranya/crm/service/DashboardServiceTest.java
+++ b/backend/src/test/java/aranya/crm/service/DashboardServiceTest.java
@@ -1,0 +1,184 @@
+package aranya.crm.service;
+
+import aranya.crm.dto.response.DashboardResponse;
+import aranya.crm.entity.Client;
+import aranya.crm.entity.ClientCase;
+import aranya.crm.entity.Role;
+import aranya.crm.entity.User;
+import aranya.crm.entity.UserRole;
+import aranya.crm.entity.VisitReport;
+import aranya.crm.repository.ClientRepository;
+import aranya.crm.repository.VisitReportRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DashboardServiceTest {
+
+    @Mock
+    private ClientRepository clientRepository;
+
+    @Mock
+    private CaseService caseService;
+
+    @Mock
+    private VisitReportRepository visitReportRepository;
+
+    @InjectMocks
+    private DashboardService dashboardService;
+
+    @Test
+    @DisplayName("Social worker dashboard returns visible dynamic data blocks")
+    void getDashboard_returnsSocialWorkerBlocks() {
+        User user = userWithRole(7L, "SOCIAL_WORKER");
+        Client client = client(12L, "Venerable Hui Ming", "释慧明");
+        ClientCase clientCase = new ClientCase();
+        clientCase.setId(20L);
+        clientCase.setCaseCode("CASE-2026-001");
+        clientCase.setClient(client);
+        clientCase.setStatus("OPEN");
+        clientCase.setColorCode("RED");
+        clientCase.setOpenedAt(LocalDateTime.of(2026, 1, 20, 9, 30));
+
+        when(clientRepository.countByMembershipStatusIgnoreCase("ACTIVE")).thenReturn(3L);
+        when(caseService.countActiveCases()).thenReturn(2L);
+        when(caseService.countUrgentCases()).thenReturn(1L);
+        when(caseService.getActiveCases(5)).thenReturn(List.of(clientCase));
+        when(visitReportRepository.findAllByOrderByCreatedAtDescIdDesc(PageRequest.of(0, 5)))
+                .thenReturn(List.of());
+
+        DashboardResponse response = dashboardService.getDashboard(authentication(user, "SOCIAL_WORKER"));
+
+        assertThat(response.getSections()).extracting(DashboardResponse.Section::getId)
+                .containsExactly("sw.stats", "sw.recent_cases", "sw.recent_reports", "sw.quick_actions");
+        DashboardResponse.Section stats = response.getSections().get(0);
+        assertThat(stats.getStats()).extracting(DashboardResponse.Stat::getId)
+                .containsExactly("activeMonastics", "openCases", "urgentCases", "pendingReports");
+        assertThat(stats.getStats()).extracting(DashboardResponse.Stat::getValue)
+                .containsExactly("3", "2", "1", "0");
+        DashboardResponse.Item recentCase = response.getSections().get(1).getItems().get(0);
+        assertThat(recentCase.getId()).isEqualTo("20");
+        assertThat(recentCase.getCaseCode()).isEqualTo("CASE-2026-001");
+        assertThat(recentCase.getClientId()).isEqualTo("12");
+        assertThat(recentCase.getClientNameEn()).isEqualTo("Venerable Hui Ming");
+        assertThat(recentCase.getClientNameChn()).isEqualTo("释慧明");
+        assertThat(recentCase.getStatusCode()).isEqualTo("OPEN");
+        assertThat(recentCase.getColorCode()).isEqualTo("RED");
+        assertThat(response.getSections().get(3).getActions()).extracting(DashboardResponse.Action::getId)
+                .containsExactly("new_case", "add_client");
+    }
+
+    @Test
+    @DisplayName("Volunteer dashboard returns only own report data blocks")
+    void getDashboard_returnsVolunteerBlocks() {
+        User user = userWithRole(9L, "VOLUNTEER");
+        Client client = client(15L, "Venerable Sona", "释苏那");
+        VisitReport report = new VisitReport();
+        report.setId(30L);
+        report.setClient(client);
+        report.setCreatedBy(user);
+        report.setDateOfVisit(LocalDate.of(2026, 5, 1));
+        report.setTypeOfVisit("Temple Visit");
+        report.setCreatedAt(LocalDateTime.of(2026, 5, 2, 10, 0));
+
+        when(visitReportRepository.countByCreatedById(9L)).thenReturn(1L);
+        when(visitReportRepository.findByCreatedByIdOrderByCreatedAtDescIdDesc(9L, PageRequest.of(0, 5)))
+                .thenReturn(List.of(report));
+
+        DashboardResponse response = dashboardService.getDashboard(authentication(user, "VOLUNTEER"));
+
+        assertThat(response.getSections()).extracting(DashboardResponse.Section::getId)
+                .containsExactly("volunteer.report_stats", "volunteer.my_recent_reports", "volunteer.quick_actions");
+        assertThat(response.getSections().get(0).getStats().get(0).getId()).isEqualTo("myReportCount");
+        assertThat(response.getSections().get(0).getStats().get(0).getValue()).isEqualTo("1");
+        DashboardResponse.Item item = response.getSections().get(1).getItems().get(0);
+        assertThat(item.getId()).isEqualTo("30");
+        assertThat(item.getClientNameEn()).isEqualTo("Venerable Sona");
+        assertThat(item.getReportType()).isEqualTo("Temple Visit");
+        assertThat(response.getSections().get(2).getActions()).extracting(DashboardResponse.Action::getId)
+                .containsExactly("submit_report");
+    }
+
+    @Test
+    @DisplayName("Multi-role dashboard merges sections without duplicates")
+    void getDashboard_mergesMultiRoleSectionsWithoutDuplicates() {
+        User user = userWithRole(11L, "VOLUNTEER", "SOCIAL_WORKER");
+        when(visitReportRepository.countByCreatedById(11L)).thenReturn(0L);
+        when(visitReportRepository.findByCreatedByIdOrderByCreatedAtDescIdDesc(11L, PageRequest.of(0, 5)))
+                .thenReturn(List.of());
+        when(clientRepository.countByMembershipStatusIgnoreCase("ACTIVE")).thenReturn(0L);
+        when(caseService.countActiveCases()).thenReturn(0L);
+        when(caseService.countUrgentCases()).thenReturn(0L);
+        when(caseService.getActiveCases(5)).thenReturn(List.of());
+        when(visitReportRepository.findAllByOrderByCreatedAtDescIdDesc(PageRequest.of(0, 5)))
+                .thenReturn(List.of());
+
+        DashboardResponse response = dashboardService.getDashboard(authentication(user, "VOLUNTEER", "SOCIAL_WORKER"));
+
+        assertThat(response.getSections()).extracting(DashboardResponse.Section::getId)
+                .containsExactly(
+                        "volunteer.report_stats",
+                        "volunteer.my_recent_reports",
+                        "volunteer.quick_actions",
+                        "sw.stats",
+                        "sw.recent_cases",
+                        "sw.recent_reports",
+                        "sw.quick_actions"
+                );
+        assertThat(response.getSections()).extracting(DashboardResponse.Section::getId).doesNotHaveDuplicates();
+        verify(caseService).getActiveCases(5);
+    }
+
+    private static UsernamePasswordAuthenticationToken authentication(User user, String... roles) {
+        return new UsernamePasswordAuthenticationToken(
+                user,
+                null,
+                List.of(roles).stream()
+                        .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+                        .toList()
+        );
+    }
+
+    private static User userWithRole(Long id, String... roleNames) {
+        User user = new User();
+        user.setId(id);
+        user.setUsername("user-" + id);
+        user.setEmail("user" + id + "@test.com");
+        user.setFullName("User " + id);
+        user.setStatus("ACTIVE");
+        for (String roleName : roleNames) {
+            Role role = new Role();
+            role.setName(roleName);
+            UserRole userRole = new UserRole();
+            userRole.setUser(user);
+            userRole.setRole(role);
+            user.getUserRoles().add(userRole);
+        }
+        return user;
+    }
+
+    private static Client client(Long id, String nameEn, String nameChn) {
+        Client client = new Client();
+        client.setId(id);
+        client.setAbbr("C" + id);
+        client.setNameEn(nameEn);
+        client.setNameChn(nameChn);
+        client.setMembershipStatus("ACTIVE");
+        return client;
+    }
+}

--- a/docs/System Design/01-api-spec.md
+++ b/docs/System Design/01-api-spec.md
@@ -40,15 +40,15 @@ Requests and responses use JSON unless otherwise stated.
 Content-Type: application/json
 ```
 
-### Server-Driven UI Contract
+### Dashboard Data Contract
 
-Aranya CRM uses Server-Driven UI (SDUI) for role-aware page composition. SDUI APIs must use a shared design-system language so clients can render server-provided screens consistently.
+Aranya CRM Dashboard uses a lightweight server-driven data contract for role-aware page composition. The backend decides which Dashboard data blocks are visible to the current user, while the frontend owns layout, component choice, labels, colors, sizing, and Figma-specific rendering.
 
 Shared envelope:
 
 ```json
 {
-  "designSystem": { "name": "aranya-crm-sdui", "version": "1.0" },
+  "designSystem": { "name": "aranya-crm-dashboard", "version": "1.0" },
   "screen": { "id": "dashboard", "version": "2026-05-13" },
   "sections": [],
   "metadata": { "generatedAt": "2026-05-13T10:00:00+08:00" }
@@ -59,31 +59,26 @@ Shared primitives:
 
 | Primitive | Shape / Notes |
 | --- | --- |
-| Localized text | `{ "zh": "中文", "en": "English" }` |
-| Section | `id`, `type`, optional `title`, optional `items`, optional `actions` |
-| Action | `id`, `type`, `label`, `target`; v1 supports `navigate` only |
-| List item | `id`, `primaryText`, optional `secondaryText`, optional `badges`, optional `actions` |
-| Stat item | `id`, `label`, `value`, optional `description` |
+| Section | `id`, optional `stats`, optional `items`, optional `actions` |
+| Stat item | `id`, `value` |
+| Case item | `id`, `clientId`, `clientNameChn`, `clientNameEn`, `caseCode`, `statusCode`, `colorCode`, `openedAt` |
+| Report item | `id`, `clientId`, `clientNameChn`, `clientNameEn`, `reportType`, `dateOfVisit`, `createdAt`, `createdById`, `createdByName` |
+| Action | `id`, optional `targetId` |
 
-Dashboard v1 component types:
-
-```text
-stat_card_group
-list
-alert_banner
-quick_actions
-```
+Dashboard section ids are the shared language between backend and frontend. The frontend maps these ids to fixed UI blocks defined in the frontend/Figma design.
 
 Client behavior:
 
-- Render known `designSystem.version` and known component/action types.
+- Render known `screen.id` and known `sections[].id`.
+- Use frontend-defined labels, layout, colors, table columns, and action text.
 - Ignore unknown optional sections/actions safely.
 
 Backend behavior:
 
 - Return only sections/actions the current user may see or execute.
-- Return display-ready localized text where SDUI needs it.
-- Continue enforcing authorization in business APIs; SDUI is not a security boundary.
+- Return dynamic business data only: counts, ids, business codes, dates, names, status codes, and action ids.
+- Do not return frontend-owned UI fields such as component names, labels, colors, layout, table definitions, Figma structure, or role names.
+- Continue enforcing authorization in business APIs; Dashboard data visibility is not a security boundary.
 ### Authentication
 
 Protected endpoints require a Firebase ID token:
@@ -255,14 +250,15 @@ Request body: none.
 
 Query parameters: none for v1.
 
-Successful response uses the shared SDUI envelope.
+Successful response uses the shared Dashboard data envelope.
 
 Rules:
 
 - The frontend must not send role, scope, or user id.
 - The backend derives the current user from the authenticated request.
 - `sections` contains only Dashboard sections the current user may see.
-- All section `type` values must come from the shared SDUI design-system list.
+- `sections[].id` is the only section identifier the frontend needs for Dashboard rendering.
+- The backend must not return frontend-owned UI fields such as labels, localized copy, component type, layout, color, table definition, or role name.
 - If there is no data, return count values as `"0"` and list `items` as `[]`.
 - Example values below are illustrative only; they are not seed data and must not be hard-coded.
 
@@ -273,24 +269,22 @@ Dashboard permissions are defined in `Role-Permission-Overview.md`.
 | Role | Sections |
 | --- | --- |
 | Volunteer | `volunteer.report_stats`, `volunteer.my_recent_reports`, `volunteer.quick_actions` |
-| Social Worker | `sw.notice`, `sw.stats`, `sw.recent_cases`, `sw.recent_reports`, `sw.urgent_report_alert`, `sw.quick_actions` |
-| Manager | Same as Social Worker in v1 |
+| Social Worker | `sw.stats`, `sw.recent_cases`, `sw.recent_reports`, `sw.quick_actions` |
+| Manager | Same as Social Worker |
 
 A multi-role user receives the union of allowed sections. Duplicate sections should be returned once.
 
 #### Section Data Rules
 
-| Section | Type | Visible to | Data rule |
-| --- | --- | --- | --- |
-| `volunteer.report_stats` | `stat_card_group` | Volunteer | Count reports where `visit_report.created_by = currentUser.id` |
-| `volunteer.my_recent_reports` | `list` | Volunteer | Latest 5 reports where `visit_report.created_by = currentUser.id`, sorted by `created_at DESC, id DESC` |
-| `volunteer.quick_actions` | `quick_actions` | Volunteer | Include report creation action if user can create reports |
-| `sw.notice` | `alert_banner` | Social Worker, Manager | Informational role/context notice |
-| `sw.stats` | `stat_card_group` | Social Worker, Manager | Active monastics, open cases, urgent cases, pending reports |
-| `sw.recent_cases` | `list` | Social Worker, Manager | Latest 5 cases joined with client, sorted by `opened_at DESC, id DESC` |
-| `sw.recent_reports` | `list` | Social Worker, Manager | Latest 5 reports joined with client/user, sorted by `created_at DESC, id DESC` |
-| `sw.urgent_report_alert` | `alert_banner` | Social Worker, Manager | Show only when pending urgent report count is greater than 0 |
-| `sw.quick_actions` | `quick_actions` | Social Worker, Manager | Include case/client creation actions if user can execute them |
+| Section | Visible to | Data rule |
+| --- | --- | --- |
+| `volunteer.report_stats` | Volunteer | Count reports where `visit_report.created_by = currentUser.id` |
+| `volunteer.my_recent_reports` | Volunteer | Latest 5 reports where `visit_report.created_by = currentUser.id`, sorted by `created_at DESC, id DESC` |
+| `volunteer.quick_actions` | Volunteer | Include `submit_report` action if user can create reports |
+| `sw.stats` | Social Worker, Manager | Active monastics, open cases, urgent cases, pending reports |
+| `sw.recent_cases` | Social Worker, Manager | Latest 5 non-closed cases joined with client, sorted by `opened_at DESC, id DESC` |
+| `sw.recent_reports` | Social Worker, Manager | Latest 5 reports joined with client/user, sorted by `created_at DESC, id DESC` |
+| `sw.quick_actions` | Social Worker, Manager | Include `new_case` and `add_client` actions if user can execute them |
 
 Stat rules:
 
@@ -305,7 +299,7 @@ Stat rules:
 Report workflow schema gap:
 
 - `visit_report` currently lacks `status`, `urgent`, `resolved_at`, and `resolved_by`.
-- Until those fields exist, the backend may omit `sw.urgent_report_alert`, return pending report count as `"0"`, and omit urgent/status badges.
+- Until those fields exist, the backend returns pending report count as `"0"` and does not return an urgent report banner section.
 
 #### Example Response
 
@@ -313,42 +307,57 @@ This is one Social Worker / Manager example. Volunteer uses the same envelope bu
 
 ```json
 {
-  "designSystem": { "name": "aranya-crm-sdui", "version": "1.0" },
+  "designSystem": { "name": "aranya-crm-dashboard", "version": "1.0" },
   "screen": { "id": "dashboard", "version": "2026-05-13" },
   "sections": [
     {
       "id": "sw.stats",
-      "type": "stat_card_group",
-      "title": { "zh": "概览", "en": "Overview" },
-      "items": [
+      "stats": [
         {
           "id": "activeMonastics",
-          "label": { "zh": "在册僧人", "en": "Active Monastics" },
-          "value": "0",
-          "description": { "zh": "活跃会员", "en": "Active members" }
+          "value": "3"
         },
         {
           "id": "openCases",
-          "label": { "zh": "进行中个案", "en": "Open Cases" },
+          "value": "2"
+        },
+        {
+          "id": "urgentCases",
+          "value": "1"
+        },
+        {
+          "id": "pendingReports",
           "value": "0"
         }
       ]
     },
     {
       "id": "sw.recent_cases",
-      "type": "list",
-      "title": { "zh": "最近个案", "en": "Recent Cases" },
+      "items": [
+        {
+          "id": "20",
+          "clientId": "12",
+          "clientNameChn": "释慧明",
+          "clientNameEn": "Venerable Hui Ming",
+          "caseCode": "CASE-2026-001",
+          "statusCode": "OPEN",
+          "colorCode": "RED",
+          "openedAt": "2026-01-20T09:30"
+        }
+      ]
+    },
+    {
+      "id": "sw.recent_reports",
       "items": []
     },
     {
       "id": "sw.quick_actions",
-      "type": "quick_actions",
       "actions": [
         {
-          "id": "new_case",
-          "type": "navigate",
-          "label": { "zh": "新建个案", "en": "New Case" },
-          "target": { "route": "cases.create", "path": "/cases/new" }
+          "id": "new_case"
+        },
+        {
+          "id": "add_client"
         }
       ]
     }
@@ -361,7 +370,7 @@ Response codes:
 
 | HTTP | Meaning |
 | --- | --- |
-| 200 | Dashboard SDUI screen returned |
+| 200 | Dashboard data screen returned |
 | 401 | Authentication required or token invalid |
 | 403 | Authenticated user cannot access Dashboard |
 ## 2.4 User Management

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -8,7 +8,5 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 *.local
-.env
-.env.*
 !.env.example
 .envrc


### PR DESCRIPTION
- 替换旧 Dashboard mock 接口，改为 GET /api/v1/dashboard
- 新增 DashboardService，根据用户角色组装可见数据块
- 重构 DashboardResponse，仅返回动态业务数据和 section id
- 新增 VisitReportRepository，支持报告统计和最近报告查询
- 扩展 ClientRepository，支持 active monastics 统计
- 接入已有 CaseService，返回进行中个案和紧急个案数据
- 新增 Dashboard controller/service 测试，覆盖角色差异和旧接口移除

DashboardController.java

将旧的 /api/dashboard mock 接口替换为新的 GET /api/v1/dashboard 接入 DashboardService
删除旧硬编码 mock 数据
DashboardResponse.java

重构 Dashboard response DTO
返回动态数据结构：designSystem、screen、sections、metadata
section 内只返回业务数据、id、code、日期、人员名、action id
不返回前端固定的 UI 样式、layout、label、组件定义
DashboardService.java

新增 Dashboard 业务服务层
根据当前用户角色组装不同 dashboard 数据块
Volunteer 返回自己的报告统计、最近报告、提交报告 action
Social Worker / Manager 返回统计数据、最近个案、最近报告、快捷操作
暂时将 pendingReports 按当前 schema 降级为 "0"
ClientRepository.java

新增 active monastics 统计查询：countByMembershipStatusIgnoreCase VisitReportRepository.java

新增报告查询仓储
支持统计当前用户报告数
支持查询当前用户最近报告
支持查询所有最近报告