### PR TITLE
feat: Build manager client and case views

### DIFF
--- a/frontend/src/features/cases/components/CaseIntensityDot.tsx
+++ b/frontend/src/features/cases/components/CaseIntensityDot.tsx
@@ -1,0 +1,5 @@
+import type { CaseColorCode } from '../types'
+
+export function CaseIntensityDot({ colorCode }: { colorCode: CaseColorCode }) {
+  return <span className={`case-intensity-dot case-intensity-${colorCode.toLowerCase()}`} aria-hidden="true" />
+}

--- a/frontend/src/features/cases/components/CaseStatusBadge.tsx
+++ b/frontend/src/features/cases/components/CaseStatusBadge.tsx
@@ -1,0 +1,20 @@
+import type { CaseStatus } from '../types'
+
+export type CaseDisplayStatus = CaseStatus | 'WEEKLY' | 'MONTHLY' | 'IN_REVIEW'
+
+const STATUS_LABELS: Record<CaseDisplayStatus, string> = {
+  OPEN: 'OPEN',
+  WEEKLY: 'WEEKLY',
+  MONTHLY: 'MONTHLY',
+  IN_REVIEW: 'IN REVIEW',
+  SUSPENDED: 'SUSPENDED',
+  CLOSED: 'CLOSED',
+}
+
+export function CaseStatusBadge({ status }: { status: CaseDisplayStatus }) {
+  return (
+    <span className={`case-status-badge case-status-${status.toLowerCase().replace('_', '-')}`}>
+      {STATUS_LABELS[status]}
+    </span>
+  )
+}

--- a/frontend/src/features/cases/components/CaseTable.tsx
+++ b/frontend/src/features/cases/components/CaseTable.tsx
@@ -1,0 +1,88 @@
+import { EmptyTableRow, SectionCard, TableShell } from '../../../shared/ui'
+import type { CaseColorCode } from '../types'
+import { CaseIntensityDot } from './CaseIntensityDot'
+import { CaseStatusBadge, type CaseDisplayStatus } from './CaseStatusBadge'
+
+export interface CaseListRow {
+  id: string
+  caseNo: string
+  dateOpened: string
+  clientNameChn: string
+  clientNameEn: string
+  tradition: string
+  socialWorker: string
+  status: CaseDisplayStatus
+  colorCode: CaseColorCode
+}
+
+interface CaseTableProps {
+  cases: CaseListRow[]
+  loading: boolean
+  onView: (caseId: string) => void
+  onAudit: (caseId: string) => void
+}
+
+export function CaseTable({ cases, loading, onView, onAudit }: CaseTableProps) {
+  return (
+    <SectionCard className="case-list-card">
+      <TableShell>
+        <table className="case-table">
+          <colgroup>
+            <col className="case-col-intensity" />
+            <col className="case-col-no" />
+            <col className="case-col-client" />
+            <col className="case-col-tradition" />
+            <col className="case-col-worker" />
+            <col className="case-col-status" />
+            <col className="case-col-opened" />
+            <col className="case-col-actions" />
+          </colgroup>
+          <thead>
+            <tr>
+              <th><span className="case-th-zh">强度</span><span className="case-th-en">Intensity</span></th>
+              <th><span className="case-th-zh">个案编号</span><span className="case-th-en">Case No.</span></th>
+              <th><span className="case-th-zh">僧人</span><span className="case-th-en">Monastic</span></th>
+              <th><span className="case-th-zh">传承</span><span className="case-th-en">Tradition</span></th>
+              <th><span className="case-th-zh">主要社工</span><span className="case-th-en">Caseworker</span></th>
+              <th><span className="case-th-zh">状态</span><span className="case-th-en">Status</span></th>
+              <th><span className="case-th-zh">开案日期</span><span className="case-th-en">Opened</span></th>
+              <th><span className="case-th-zh">操作</span><span className="case-th-en">Actions</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <EmptyTableRow colSpan={8} message="加载中... / Loading..." />
+            ) : cases.length === 0 ? (
+              <EmptyTableRow colSpan={8} message="暂无匹配个案 / No cases found" />
+            ) : (
+              cases.map((item) => (
+                <tr key={item.id} className={item.status === 'CLOSED' ? 'case-row-closed' : undefined}>
+                  <td><CaseIntensityDot colorCode={item.colorCode} /></td>
+                  <td><span className="case-cell-main">{item.caseNo}</span></td>
+                  <td>
+                    <span className="case-cell-main">{item.clientNameChn}</span>
+                    <span className="case-cell-sub">Ven. {item.clientNameEn}</span>
+                  </td>
+                  <td><span className="case-cell-main">{item.tradition}</span></td>
+                  <td><span className="case-cell-main">{item.socialWorker}</span></td>
+                  <td><CaseStatusBadge status={item.status} /></td>
+                  <td><span className="case-cell-main">{item.dateOpened}</span></td>
+                  <td>
+                    <div className="case-action-group">
+                      <button className="case-action-link" type="button" onClick={() => onView(item.id)}>
+                        查看 · View
+                      </button>
+                      <button className="case-action-link" type="button" onClick={() => onAudit(item.id)}>
+                        审计 · Audit
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </TableShell>
+    </SectionCard>
+  )
+}

--- a/frontend/src/features/cases/components/CaseToolbar.tsx
+++ b/frontend/src/features/cases/components/CaseToolbar.tsx
@@ -1,0 +1,66 @@
+import type { CaseDisplayStatus } from './CaseStatusBadge'
+
+interface CaseToolbarProps {
+  search: string
+  status: string
+  caseworker: string
+  caseworkers: string[]
+  statuses: CaseDisplayStatus[]
+  onSearchChange: (value: string) => void
+  onStatusChange: (value: string) => void
+  onCaseworkerChange: (value: string) => void
+}
+
+const STATUS_LABELS: Record<CaseDisplayStatus, string> = {
+  OPEN: 'Open',
+  WEEKLY: 'Weekly',
+  MONTHLY: 'Monthly',
+  IN_REVIEW: 'In Review',
+  SUSPENDED: 'Suspended',
+  CLOSED: 'Closed',
+}
+
+export function CaseToolbar({
+  search,
+  status,
+  caseworker,
+  caseworkers,
+  statuses,
+  onSearchChange,
+  onStatusChange,
+  onCaseworkerChange,
+}: CaseToolbarProps) {
+  return (
+    <div className="case-toolbar">
+      <input
+        className="case-search-input"
+        type="text"
+        placeholder="搜索个案或僧人 · Search..."
+        value={search}
+        onChange={(event) => onSearchChange(event.target.value)}
+      />
+      <select
+        className="case-filter-select"
+        value={status}
+        onChange={(event) => onStatusChange(event.target.value)}
+        aria-label="Filter by status"
+      >
+        <option value="all">全部状态 · All Status</option>
+        {statuses.map((item) => (
+          <option key={item} value={item}>{STATUS_LABELS[item]}</option>
+        ))}
+      </select>
+      <select
+        className="case-filter-select caseworker-select"
+        value={caseworker}
+        onChange={(event) => onCaseworkerChange(event.target.value)}
+        aria-label="Filter by caseworker"
+      >
+        <option value="all">全部社工 · All Caseworkers</option>
+        {caseworkers.map((item) => (
+          <option key={item} value={item}>{item}</option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/frontend/src/features/cases/components/index.ts
+++ b/frontend/src/features/cases/components/index.ts
@@ -1,0 +1,4 @@
+export { CaseIntensityDot } from './CaseIntensityDot'
+export { CaseStatusBadge, type CaseDisplayStatus } from './CaseStatusBadge'
+export { CaseTable, type CaseListRow } from './CaseTable'
+export { CaseToolbar } from './CaseToolbar'

--- a/frontend/src/features/cases/hooks/index.ts
+++ b/frontend/src/features/cases/hooks/index.ts
@@ -1,0 +1,6 @@
+export {
+  caseQueryKeys,
+  useCase,
+  useCases,
+  useCreateCase,
+} from './useCases'

--- a/frontend/src/features/cases/hooks/useCases.ts
+++ b/frontend/src/features/cases/hooks/useCases.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { createCase, fetchCaseById, fetchCases } from '../api/case.api'
+import type { Case } from '../types'
+
+export const caseQueryKeys = {
+  all: ['cases'] as const,
+  lists: () => [...caseQueryKeys.all, 'list'] as const,
+  list: () => [...caseQueryKeys.lists()] as const,
+  details: () => [...caseQueryKeys.all, 'detail'] as const,
+  detail: (id: string) => [...caseQueryKeys.details(), id] as const,
+}
+
+export function useCases() {
+  return useQuery({
+    queryKey: caseQueryKeys.list(),
+    queryFn: fetchCases,
+  })
+}
+
+export function useCase(id: string | undefined) {
+  return useQuery({
+    queryKey: id ? caseQueryKeys.detail(id) : caseQueryKeys.details(),
+    queryFn: () => fetchCaseById(id!),
+    enabled: Boolean(id),
+  })
+}
+
+export function useCreateCase() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: Omit<Case, 'id'>) => createCase(data),
+    onSuccess: (item) => {
+      queryClient.invalidateQueries({ queryKey: caseQueryKeys.lists() })
+      queryClient.setQueryData(caseQueryKeys.detail(item.id), item)
+    },
+  })
+}

--- a/frontend/src/features/cases/pages/CaseListPage.tsx
+++ b/frontend/src/features/cases/pages/CaseListPage.tsx
@@ -1,10 +1,155 @@
-import { EmptyState, PageHeader } from '../../../shared/ui'
+import { useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAccess } from '../../../shared/auth'
+import { PageHeader } from '../../../shared/ui'
+import {
+  CaseTable,
+  CaseToolbar,
+  type CaseListRow,
+} from '../components'
+import { useCases } from '../hooks'
+import type { Case, CaseColorCode } from '../types'
+import './cases.css'
+
+const CASE_DISPLAY_OVERRIDES: Record<string, Partial<CaseListRow>> = {
+  'case-001': {
+    caseNo: 'ARANYA/2026/C/100',
+    clientNameChn: '释慧明',
+    clientNameEn: 'Sumedho',
+    socialWorker: 'Sarah (SW)',
+    status: 'WEEKLY',
+  },
+  'case-002': {
+    caseNo: 'ARANYA/2026/C/101',
+    clientNameChn: '释觉慧',
+    clientNameEn: 'Ajahn Chah',
+    socialWorker: 'Sarah (SW)',
+    status: 'MONTHLY',
+  },
+  'case-003': {
+    caseNo: 'ARANYA/2026/C/102',
+    clientNameChn: '释德行',
+    clientNameEn: 'Bodhi',
+    socialWorker: 'Sarah (SW)',
+    status: 'IN_REVIEW',
+  },
+  'case-004': {
+    caseNo: 'ARANYA/2026/C/103',
+    clientNameChn: '释妙音',
+    clientNameEn: 'Pasanno',
+    socialWorker: 'Sarah (SW)',
+    status: 'OPEN',
+  },
+  'case-005': {
+    caseNo: 'ARANYA/2025/C/090',
+    clientNameChn: '空白师父',
+    clientNameEn: 'Kong Bai',
+    socialWorker: 'Sarah (SW)',
+    status: 'CLOSED',
+    colorCode: 'GREY',
+  },
+}
+
+const COLOR_ORDER: Record<CaseColorCode, number> = {
+  RED: 1,
+  ORANGE: 2,
+  YELLOW: 3,
+  GREEN: 4,
+  GREY: 5,
+  BLACK: 6,
+}
 
 export function CaseListPage() {
+  const navigate = useNavigate()
+  const { canFeature } = useAccess()
+  const { data: cases = [], isLoading } = useCases()
+  const [search, setSearch] = useState('')
+  const [statusFilter, setStatusFilter] = useState<string>('all')
+  const [caseworkerFilter, setCaseworkerFilter] = useState<string>('all')
+
+  const rows = useMemo(() => {
+    return cases.map(toCaseListRow).sort((a, b) => {
+      const colorDiff = COLOR_ORDER[a.colorCode] - COLOR_ORDER[b.colorCode]
+      if (colorDiff !== 0) return colorDiff
+      return b.dateOpened.localeCompare(a.dateOpened)
+    })
+  }, [cases])
+
+  const statuses = useMemo(() => unique(rows.map((item) => item.status)), [rows])
+  const caseworkers = useMemo(() => unique(rows.map((item) => item.socialWorker)), [rows])
+
+  const filteredRows = useMemo(() => {
+    const q = search.trim().toLowerCase()
+
+    return rows.filter((item) => {
+      const matchesSearch =
+        !q ||
+        item.caseNo.toLowerCase().includes(q) ||
+        item.clientNameChn.includes(q) ||
+        item.clientNameEn.toLowerCase().includes(q)
+      const matchesStatus = statusFilter === 'all' || item.status === statusFilter
+      const matchesCaseworker = caseworkerFilter === 'all' || item.socialWorker === caseworkerFilter
+      return matchesSearch && matchesStatus && matchesCaseworker
+    })
+  }, [rows, search, statusFilter, caseworkerFilter])
+
   return (
-    <>
-      <PageHeader titleZh="个案管理" titleEn="Cases" />
-      <EmptyState message="Coming soon..." />
-    </>
+    <div className="case-page">
+      <PageHeader
+        titleZh="个案管理"
+        titleEn={`Case Management · ${filteredRows.length} 个个案`}
+        actions={(
+          <div className="case-header-actions">
+            <button className="btn-audit" type="button">
+              审计视图 · Audit View
+            </button>
+            {canFeature('cases.create') ? (
+              <button className="btn-primary" type="button" onClick={() => navigate('/cases/new')}>
+                + 新建个案 · New Case
+              </button>
+            ) : null}
+          </div>
+        )}
+      />
+
+      <CaseToolbar
+        search={search}
+        status={statusFilter}
+        caseworker={caseworkerFilter}
+        caseworkers={caseworkers}
+        statuses={statuses}
+        onSearchChange={setSearch}
+        onStatusChange={setStatusFilter}
+        onCaseworkerChange={setCaseworkerFilter}
+      />
+
+      <CaseTable
+        cases={filteredRows}
+        loading={isLoading}
+        onView={(caseId) => navigate(`/cases/${caseId}`)}
+        onAudit={(caseId) => navigate(`/cases/${caseId}?mode=audit`)}
+      />
+    </div>
   )
+}
+
+function toCaseListRow(item: Case): CaseListRow {
+  const override = CASE_DISPLAY_OVERRIDES[item.id] ?? {}
+
+  return {
+    id: item.id,
+    caseNo: item.caseNo.replaceAll('_', '/'),
+    dateOpened: item.dateOpened,
+    clientNameChn: item.clientNameChn,
+    clientNameEn: item.clientNameEn,
+    tradition: item.tradition,
+    socialWorker: item.socialWorker,
+    status: item.status,
+    colorCode: item.colorCode,
+    ...override,
+  }
+}
+
+function unique<T extends string>(items: T[]): T[] {
+  return Array.from(new Set(items))
 }

--- a/frontend/src/features/cases/pages/cases.css
+++ b/frontend/src/features/cases/pages/cases.css
@@ -1,0 +1,264 @@
+.case-page {
+  width: 100%;
+}
+
+.case-page .page-header {
+  align-items: flex-start;
+}
+
+.case-page .page-title {
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
+.case-header-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.btn-audit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 36px;
+  padding: 0 18px;
+  border: 1px solid #6d28d9;
+  border-radius: 6px;
+  background: #6d28d9;
+  color: #ffffff;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.btn-audit:hover {
+  background: #5b21b6;
+}
+
+.case-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 22px;
+  flex-wrap: wrap;
+}
+
+.case-search-input,
+.case-filter-select {
+  height: 36px;
+  border: 1px solid #d7dce5;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #243047;
+  font-size: 13px;
+  outline: none;
+}
+
+.case-search-input {
+  width: 260px;
+  padding: 0 12px;
+}
+
+.case-search-input::placeholder {
+  color: #8a94a6;
+}
+
+.case-filter-select {
+  min-width: 150px;
+  padding: 0 10px;
+  cursor: pointer;
+}
+
+.caseworker-select {
+  min-width: 190px;
+}
+
+.case-list-card {
+  width: 100%;
+  margin-top: 16px;
+}
+
+.case-table {
+  width: 100%;
+  min-width: 1080px;
+  table-layout: fixed;
+  border-collapse: collapse;
+  background: #ffffff;
+}
+
+.case-table thead tr {
+  height: 56px;
+  background: #fbfcfe;
+}
+
+.case-table th {
+  padding: 12px 16px;
+  border-bottom: 1px solid #eef1f5;
+  text-align: left;
+  vertical-align: middle;
+  font-weight: 500;
+}
+
+.case-table tbody tr {
+  height: 62px;
+  border-bottom: 1px solid #eef1f5;
+}
+
+.case-table tbody tr:last-child {
+  border-bottom: 0;
+}
+
+.case-table tbody tr:hover {
+  background: #fbfcfe;
+}
+
+.case-table td {
+  padding: 12px 16px;
+  vertical-align: middle;
+}
+
+.case-th-zh,
+.case-th-en,
+.case-cell-main,
+.case-cell-sub {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.case-th-zh {
+  color: #8a94a6;
+  font-size: 12px;
+  line-height: 1.2;
+}
+
+.case-th-en {
+  margin-top: 2px;
+  color: #a7b0c0;
+  font-size: 12px;
+  line-height: 1.15;
+}
+
+.case-cell-main {
+  color: #18233a;
+  font-size: 13px;
+  line-height: 1.25;
+}
+
+.case-cell-sub {
+  margin-top: 3px;
+  color: #8a94a6;
+  font-size: 12px;
+  line-height: 1.2;
+}
+
+.case-row-closed .case-cell-main,
+.case-row-closed .case-cell-sub,
+.case-row-closed .case-action-link {
+  color: #98a2b3;
+}
+
+.case-intensity-dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+}
+
+.case-intensity-red { background: #dc3545; }
+.case-intensity-orange { background: #f97316; }
+.case-intensity-yellow { background: #fbbf24; }
+.case-intensity-green { background: #22a849; }
+.case-intensity-grey,
+.case-intensity-black { background: #8a949b; }
+
+.case-status-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 3px 9px;
+  border-radius: 5px;
+  font-size: 12px;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.case-status-open {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.case-status-weekly {
+  background: #ede9fe;
+  color: #6d28d9;
+}
+
+.case-status-monthly {
+  background: #fef3c7;
+  color: #b45309;
+}
+
+.case-status-in-review {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.case-status-suspended {
+  background: #fff7ed;
+  color: #c2410c;
+}
+
+.case-status-closed {
+  background: #eeeeee;
+  color: #a3a3a3;
+}
+
+.case-action-group {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.case-action-link {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: #18233a;
+  cursor: pointer;
+  font-size: 13px;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.case-action-link:hover {
+  color: #6d28d9;
+}
+
+.case-col-intensity { width: 9%; }
+.case-col-no { width: 18%; }
+.case-col-client { width: 17%; }
+.case-col-tradition { width: 11%; }
+.case-col-worker { width: 12%; }
+.case-col-status { width: 12%; }
+.case-col-opened { width: 11%; }
+.case-col-actions { width: 10%; }
+
+@media (max-width: 0) {
+  .case-page {
+    max-width: none;
+  }
+
+  .case-page .page-header {
+    flex-direction: column;
+  }
+
+  .case-header-actions {
+    justify-content: flex-start;
+  }
+}

--- a/frontend/src/features/clients/pages/ClientListPage.tsx
+++ b/frontend/src/features/clients/pages/ClientListPage.tsx
@@ -1,19 +1,72 @@
-import { useMemo, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useEffect, useMemo, useState } from 'react'
+import type { FormEvent, ReactNode } from 'react'
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { useAccess } from '../../../shared/auth'
-import { PageHeader } from '../../../shared/ui'
-import { ClientTable, ClientToolbar } from '../components'
-import { useClients } from '../hooks'
+import { EmptyState } from '../../../shared/ui'
+import { MembershipBadge } from '../components'
+import { useClients, useCreateClient } from '../hooks'
+import type { Client } from '../types'
 import './clients.css'
+
+const MEMBERSHIP_STATUSES: Array<Client['membershipStatus']> = [
+  'Active',
+  'Inactive',
+  'Discharged',
+  'Withdrawn',
+  'Deceased',
+]
+
+const TRADITIONS: Array<Client['buddhistTradition']> = [
+  'Theravada',
+  'Mahayana',
+  'Vajrayana',
+]
+
+const ORDINATION_STATUSES: Array<Client['ordinationStatus']> = [
+  'Bhikkhu',
+  'Bhikkhuni',
+  'Samanera',
+  'Sikkhamana',
+  'Sayalay',
+]
+
+interface NewClientForm {
+  nameChn: string
+  nameEn: string
+  abbr: string
+  buddhistTradition: Client['buddhistTradition']
+  ordinationStatus: Client['ordinationStatus']
+  area: string
+}
+
+const initialNewClientForm: NewClientForm = {
+  nameChn: '',
+  nameEn: '',
+  abbr: '',
+  buddhistTradition: 'Mahayana',
+  ordinationStatus: 'Bhikkhu',
+  area: '',
+}
 
 export function ClientListPage() {
   const { canFeature } = useAccess()
   const navigate = useNavigate()
+  const { id: routeClientId } = useParams<{ id: string }>()
+  const [searchParams, setSearchParams] = useSearchParams()
   const { data: clients = [], isLoading } = useClients()
+  const createClient = useCreateClient()
   const [search, setSearch] = useState('')
   const [filterStatus, setFilterStatus] = useState<string>('all')
   const [filterTradition, setFilterTradition] = useState<string>('all')
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [showCreateModal, setShowCreateModal] = useState(false)
+  const [newClientForm, setNewClientForm] = useState<NewClientForm>(initialNewClientForm)
+
+  const selectedClientId = searchParams.get('client') ?? routeClientId
+  const canCreateClient = canFeature('clients.create')
   const canUpdateClient = canFeature('clients.update')
+  const canDeleteClient = canFeature('clients.delete') || canUpdateClient
+  const canViewDetailedProfile = canFeature('clients.view.full')
 
   const filtered = useMemo(() => {
     return clients.filter((client) => {
@@ -29,27 +82,469 @@ export function ClientListPage() {
     })
   }, [clients, search, filterStatus, filterTradition])
 
+  const selectedClient = useMemo(() => {
+    return filtered.find((client) => client.id === selectedClientId) ?? filtered[0]
+  }, [filtered, selectedClientId])
+
+  useEffect(() => {
+    if (!selectedClient || selectedClient.id === selectedClientId) return
+    setSearchParams({ client: selectedClient.id }, { replace: true })
+  }, [selectedClient, selectedClientId, setSearchParams])
+
+  function selectClient(clientId: string) {
+    setShowDeleteConfirm(false)
+    setSearchParams({ client: clientId })
+  }
+
+  async function submitNewClient(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const created = await createClient.mutateAsync(buildNewClientPayload(newClientForm))
+    setNewClientForm(initialNewClientForm)
+    setShowCreateModal(false)
+    setSearchParams({ client: created.id })
+  }
+
+  function updateNewClientField<Key extends keyof NewClientForm>(key: Key, value: NewClientForm[Key]) {
+    setNewClientForm((current) => ({ ...current, [key]: value }))
+  }
+
+  function closeCreateModal() {
+    if (createClient.isPending) return
+    setShowCreateModal(false)
+    setNewClientForm(initialNewClientForm)
+  }
+
   return (
-    <>
-      <PageHeader titleZh="僧人档案" titleEn="Clients" />
+    <div className="client-workspace">
+      <aside className="client-directory" aria-label="Client profiles">
+        <div className="client-directory-header">
+          <div>
+            <h2>僧人档案</h2>
+            <span>Client Profiles</span>
+          </div>
+        </div>
 
-      <ClientToolbar
-        search={search}
-        filterStatus={filterStatus}
-        filterTradition={filterTradition}
-        onSearchChange={setSearch}
-        onStatusChange={setFilterStatus}
-        onTraditionChange={setFilterTradition}
-        onCreate={() => navigate('/clients/new')}
-      />
+        <div className="client-directory-controls">
+          <input
+            className="search-input client-directory-search"
+            type="text"
+            placeholder="搜索法名或缩写 · Search..."
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+          />
+          <div className="client-directory-filters">
+            <select
+              className="filter-select"
+              value={filterTradition}
+              onChange={(event) => setFilterTradition(event.target.value)}
+              aria-label="Filter by tradition"
+            >
+              <option value="all">传承 · All</option>
+              {TRADITIONS.map((tradition) => (
+                <option key={tradition} value={tradition}>{tradition}</option>
+              ))}
+            </select>
+            <select
+              className="filter-select"
+              value={filterStatus}
+              onChange={(event) => setFilterStatus(event.target.value)}
+              aria-label="Filter by status"
+            >
+              <option value="all">状态 · All</option>
+              {MEMBERSHIP_STATUSES.map((status) => (
+                <option key={status} value={status}>{status}</option>
+              ))}
+            </select>
+          </div>
+          {canCreateClient ? (
+            <button className="btn-primary client-create-btn" type="button" onClick={() => setShowCreateModal(true)}>
+              + 新增僧人 · New Monastic
+            </button>
+          ) : null}
+        </div>
 
-      <ClientTable
-        clients={filtered}
-        loading={isLoading}
-        canUpdateClient={canUpdateClient}
-        onView={(clientId) => navigate(`/clients/${clientId}`)}
-        onEdit={(clientId) => navigate(`/clients/${clientId}/edit`)}
-      />
-    </>
+        <div className="client-directory-list">
+          {isLoading ? (
+            <div className="client-directory-status">加载中 · Loading...</div>
+          ) : filtered.length === 0 ? (
+            <div className="client-directory-status">暂无匹配档案 · No clients found</div>
+          ) : (
+            filtered.map((client) => (
+              <button
+                key={client.id}
+                className={'client-directory-item' + (client.id === selectedClient?.id ? ' active' : '')}
+                type="button"
+                onClick={() => selectClient(client.id)}
+              >
+                <div className="client-directory-name">
+                  <strong>{client.nameChn}</strong>
+                  <span>{client.abbr}</span>
+                </div>
+                <div className="client-directory-en">{client.nameEn}</div>
+                <div className="client-directory-meta">
+                  {client.buddhistTradition} · {client.area}
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+      </aside>
+
+      <main className="client-profile-surface">
+        {selectedClient ? (
+          <ClientProfilePanel
+            client={selectedClient}
+            canUpdateClient={canUpdateClient}
+            canDeleteClient={canDeleteClient}
+            canViewDetailedProfile={canViewDetailedProfile}
+            showDeleteConfirm={showDeleteConfirm}
+            onToggleDeleteConfirm={() => setShowDeleteConfirm((value) => !value)}
+            onEdit={() => navigate(`/clients/${selectedClient.id}/edit`)}
+          />
+        ) : (
+          <EmptyState message="请选择一个僧人档案 / Select a client profile" />
+        )}
+      </main>
+
+      {showCreateModal ? (
+        <NewClientModal
+          form={newClientForm}
+          submitting={createClient.isPending}
+          error={createClient.error instanceof Error ? createClient.error.message : undefined}
+          onClose={closeCreateModal}
+          onSubmit={submitNewClient}
+          onFieldChange={updateNewClientField}
+        />
+      ) : null}
+    </div>
   )
+}
+
+interface NewClientModalProps {
+  form: NewClientForm
+  submitting: boolean
+  error?: string
+  onClose: () => void
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void
+  onFieldChange: <Key extends keyof NewClientForm>(key: Key, value: NewClientForm[Key]) => void
+}
+
+function NewClientModal({
+  form,
+  submitting,
+  error,
+  onClose,
+  onSubmit,
+  onFieldChange,
+}: NewClientModalProps) {
+  return (
+    <div className="client-modal-backdrop" role="presentation" onMouseDown={onClose}>
+      <form
+        className="client-create-modal"
+        aria-labelledby="new-client-title"
+        onMouseDown={(event) => event.stopPropagation()}
+        onSubmit={onSubmit}
+      >
+        <header className="client-create-modal-header">
+          <div>
+            <h2 id="new-client-title">新增僧人</h2>
+            <span>Add New Monastic</span>
+          </div>
+          <button className="client-modal-close" type="button" aria-label="Close" onClick={onClose}>
+            x
+          </button>
+        </header>
+
+        <div className="client-create-modal-body">
+          <ModalField label="法名（中） / Chinese Dharma Name *">
+            <input
+              className="form-input"
+              required
+              value={form.nameChn}
+              onChange={(event) => onFieldChange('nameChn', event.target.value)}
+            />
+          </ModalField>
+          <ModalField label="法名（英） / English Dharma Name *">
+            <input
+              className="form-input"
+              required
+              value={form.nameEn}
+              onChange={(event) => onFieldChange('nameEn', event.target.value)}
+            />
+          </ModalField>
+          <ModalField label="缩写 / Abbreviation *">
+            <input
+              className="form-input"
+              required
+              maxLength={8}
+              value={form.abbr}
+              onChange={(event) => onFieldChange('abbr', event.target.value.toUpperCase())}
+            />
+          </ModalField>
+          <ModalField label="传承 / Tradition *">
+            <select
+              className="form-select"
+              required
+              value={form.buddhistTradition}
+              onChange={(event) => onFieldChange('buddhistTradition', event.target.value as Client['buddhistTradition'])}
+            >
+              {TRADITIONS.map((tradition) => (
+                <option key={tradition} value={tradition}>{tradition}</option>
+              ))}
+            </select>
+          </ModalField>
+          <ModalField label="出家身份 / Ordination Status">
+            <select
+              className="form-select"
+              value={form.ordinationStatus}
+              onChange={(event) => onFieldChange('ordinationStatus', event.target.value as Client['ordinationStatus'])}
+            >
+              {ORDINATION_STATUSES.map((status) => (
+                <option key={status} value={status}>{status}</option>
+              ))}
+            </select>
+          </ModalField>
+          <ModalField label="地区 / Area / District">
+            <input
+              className="form-input"
+              value={form.area}
+              onChange={(event) => onFieldChange('area', event.target.value)}
+            />
+          </ModalField>
+        </div>
+
+        {error ? <div className="client-create-error">{error}</div> : null}
+
+        <footer className="client-create-modal-footer">
+          <button className="btn-secondary" type="button" disabled={submitting} onClick={onClose}>
+            取消 · Cancel
+          </button>
+          <button className="btn-primary" type="submit" disabled={submitting}>
+            {submitting ? '创建中 · Creating...' : '创建 · Create Monastic ->'}
+          </button>
+        </footer>
+      </form>
+    </div>
+  )
+}
+
+function ModalField({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <label className="client-modal-field">
+      <span>{label}</span>
+      {children}
+    </label>
+  )
+}
+
+interface ClientProfilePanelProps {
+  client: Client
+  canUpdateClient: boolean
+  canDeleteClient: boolean
+  canViewDetailedProfile: boolean
+  showDeleteConfirm: boolean
+  onToggleDeleteConfirm: () => void
+  onEdit: () => void
+}
+
+function ClientProfilePanel({
+  client,
+  canUpdateClient,
+  canDeleteClient,
+  canViewDetailedProfile,
+  showDeleteConfirm,
+  onToggleDeleteConfirm,
+  onEdit,
+}: ClientProfilePanelProps) {
+  return (
+    <article className="client-profile">
+      <header className="client-profile-header">
+        <div>
+          <div className="client-profile-title-row">
+            <h1>{client.nameChn} / {client.nameEn}</h1>
+            <span className="abbr-tag">{client.abbr}</span>
+            <MembershipBadge status={client.membershipStatus} />
+          </div>
+          <p>{client.buddhistTradition} · {client.ordinationStatus} · {client.area}</p>
+        </div>
+        <div className="client-profile-actions">
+          <button className="btn-secondary" type="button">
+            链接联系人 · Link Contacts
+          </button>
+          {canUpdateClient ? (
+            <button className="btn-primary" type="button" onClick={onEdit}>
+              编辑档案 · Edit Profile
+            </button>
+          ) : null}
+          {canDeleteClient ? (
+            <button className="btn-danger" type="button" onClick={onToggleDeleteConfirm}>
+              删除档案 · Delete
+            </button>
+          ) : null}
+        </div>
+      </header>
+
+      {showDeleteConfirm ? (
+        <div className="client-danger-banner">
+          <span>Manager 操作：删除档案会把记录从活跃列表移除。当前版本仅显示确认入口，等待后端删除/归档 API 接入。</span>
+          <button className="btn-secondary btn-compact" type="button" onClick={onToggleDeleteConfirm}>
+            取消 · Cancel
+          </button>
+        </div>
+      ) : null}
+
+      <ProfileSection title="基本信息 / Basic Info">
+        <InfoCell label="法名（中）" subLabel="Chinese Dharma Name" value={client.nameChn} />
+        <InfoCell label="法名（英）" subLabel="English Dharma Name" value={client.nameEn} />
+        <InfoCell label="缩写" subLabel="Abbreviation" value={client.abbr} />
+        <InfoCell label="联系电话" subLabel="Contact" value={client.contact} />
+        <InfoCell label="首选沟通方式" subLabel="Preferred Communication" value={client.preferredCommunication} />
+        <InfoCell label="WhatsApp" subLabel="WhatsApp Enabled" value={client.ableToUseWhatsApp ? '是 · Yes' : '否 · No'} />
+        <InfoCell label="首选语言" subLabel="Preferred Language" value={client.preferredLanguage} />
+        <InfoCell label="使用语言" subLabel="Spoken Language" value={client.spokenLanguage} />
+        <InfoCell label="地址" subLabel="Address" value={client.address} />
+        <InfoCell label="邮政编码" subLabel="Postal Code" value={client.postalCode} />
+        <InfoCell label="地区" subLabel="Area / District" value={client.area} />
+        <InfoCell label="居住类型" subLabel="Vihara Type" value={client.viharaType} />
+      </ProfileSection>
+
+      {canViewDetailedProfile ? (
+        <>
+          <ProfileSection title="身份文件 / Identity (IC)">
+            <InfoCell label="NRIC 英文姓名" subLabel="NRIC Full Name (English)" value={client.nricNameEn} />
+            <InfoCell label="NRIC 中文姓名" subLabel="NRIC Full Name (Chinese)" value={client.nricNameChn} />
+            <InfoCell label="NRIC 号码" subLabel="NRIC Number" value={client.nricNo} />
+            <InfoCell label="受戒证书" subLabel="Ordination Certificate" value={client.ordinationCertificate} />
+            <InfoCell label="核实日期" subLabel="Date of Verification" value={client.dateVerification} />
+          </ProfileSection>
+
+          <ProfileSection title="个人信息 / Personal">
+            <InfoCell label="性别" subLabel="Sex" value={client.sex} />
+            <InfoCell label="出生日期" subLabel="Date of Birth" value={client.dateOfBirth} />
+            <InfoCell label="年龄" subLabel="Age" value={`${client.age} 岁`} />
+            <InfoCell label="婚姻状况" subLabel="Marital Status" value={client.maritalStatus} />
+            <InfoCell label="国籍" subLabel="Nationality" value={client.nationality} />
+            <InfoCell label="族群" subLabel="Ethnicity" value={client.ethnicity} />
+            <InfoCell label="方言群" subLabel="Dialect Group" value={client.dialectGroup} />
+            <InfoCell label="紧急联系人" subLabel="Next of Kin Contact" value={client.nextOfKin} />
+          </ProfileSection>
+
+          <ProfileSection title="出家资料 / Ordination">
+            <InfoCell label="佛教传承" subLabel="Buddhist Tradition" value={client.buddhistTradition} />
+            <InfoCell label="戒别" subLabel="Ordination Status" value={client.ordinationStatus} />
+            <InfoCell label="剃度日期" subLabel="Date of Tonsure" value={client.dateTonsure} />
+            <InfoCell label="剃度地点" subLabel="Place of Tonsure" value={`${client.placeTonsure}, ${client.countryTonsure}`} />
+            <InfoCell label="受戒日期" subLabel="Date of Ordination" value={client.dateOrdination} />
+            <InfoCell label="受戒地点" subLabel="Place of Ordination" value={`${client.placeOrdination}, ${client.countryOrdination}`} />
+            <InfoCell label="戒龄" subLabel="Ordination Years" value={`${client.ordinationYears} years`} />
+          </ProfileSection>
+
+          <ProfileSection title="会员与备注 / Membership">
+            <InfoCell label="会员状态" subLabel="Membership Status" value={client.membershipStatus} />
+            <InfoCell label="加入日期" subLabel="Date Joined" value={client.dateJoined} />
+            <InfoCell label="会员备注" subLabel="Membership Remarks" value={client.membershipRemarks || '-'} />
+            <InfoCell label="整体备注" subLabel="Comments" value={client.comments || '-'} wide />
+          </ProfileSection>
+        </>
+      ) : (
+        <div className="volunteer-notice">
+          当前账户只能查看基础档案。如需完整资料，请联系 Manager。 / This account can view basic profile information only.
+        </div>
+      )}
+    </article>
+  )
+}
+
+function ProfileSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="client-profile-section">
+      <h3>{title}</h3>
+      <div className="client-profile-grid">{children}</div>
+    </section>
+  )
+}
+
+function InfoCell({
+  label,
+  subLabel,
+  value,
+  wide = false,
+}: {
+  label: string
+  subLabel: string
+  value: string | number
+  wide?: boolean
+}) {
+  return (
+    <div className={'client-info-cell' + (wide ? ' wide' : '')}>
+      <span>{label}</span>
+      <small>{subLabel}</small>
+      <strong>{value}</strong>
+    </div>
+  )
+}
+
+function buildNewClientPayload(form: NewClientForm): Omit<Client, 'id'> {
+  const today = new Date().toISOString().slice(0, 10)
+
+  return {
+    abbr: form.abbr.trim(),
+    nameEn: form.nameEn.trim(),
+    nameChn: form.nameChn.trim(),
+    nricNameEn: '',
+    nricNameChn: '',
+    nricNo: '',
+    sex: 'Male',
+    dateOfBirth: '',
+    age: 0,
+    maritalStatus: 'Never married',
+    nationality: '',
+    ethnicity: '',
+    dialectGroup: '',
+    contact: '',
+    nextOfKin: '',
+    preferredCommunication: 'Phone Call',
+    ableToUseWhatsApp: false,
+    preferredLanguage: '',
+    spokenLanguage: '',
+    address: '',
+    postalCode: '',
+    viharaType: '',
+    area: form.area.trim(),
+    membershipStatus: 'Active',
+    dateJoined: today,
+    membershipRemarks: '',
+    buddhistTradition: form.buddhistTradition,
+    ordinationStatus: form.ordinationStatus,
+    dateTonsure: '',
+    countryTonsure: '',
+    placeTonsure: '',
+    dateOrdination: '',
+    countryOrdination: '',
+    placeOrdination: '',
+    ordinationYears: 0,
+    ordinationCertificate: 'Incomplete',
+    dateVerification: '',
+    wellbeingIssues: {
+      physicalHealth: false,
+      mentalHealth: false,
+      socialSupport: false,
+      financialStability: false,
+      livingConditions: false,
+      spiritualWellbeing: false,
+      legalIssues: false,
+      substanceUse: false,
+    },
+    wellbeingRemarks: '',
+    specialNeeds: {
+      physical: false,
+      hearing: false,
+      visual: false,
+      intellectual: false,
+    },
+    specialNeedsRemarks: '',
+    bankTransfer: false,
+    payNow: false,
+    comments: '',
+  }
 }

--- a/frontend/src/features/clients/pages/clients.css
+++ b/frontend/src/features/clients/pages/clients.css
@@ -3,6 +3,400 @@
 
 /* ── List Page ── */
 
+.client-workspace {
+  display: grid;
+  grid-template-columns: 286px minmax(0, 1fr);
+  height: calc(100vh - 56px);
+  margin: -32px;
+  background: #f6f7f9;
+  overflow: hidden;
+}
+
+.client-directory {
+  display: flex;
+  height: 100%;
+  min-width: 0;
+  flex-direction: column;
+  border-right: 1px solid #d9dee8;
+  background: #ffffff;
+  overflow: hidden;
+}
+
+.client-directory-header {
+  padding: 18px 16px 12px;
+  border-bottom: 1px solid #e8ebf0;
+}
+
+.client-directory-header h2 {
+  margin: 0;
+  color: #111827;
+  font-size: 16px;
+  font-weight: 800;
+}
+
+.client-directory-header span {
+  display: block;
+  margin-top: 2px;
+  color: #697386;
+  font-size: 12px;
+}
+
+.client-directory-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 12px 10px;
+  border-bottom: 1px solid #e8ebf0;
+}
+
+.client-directory-search {
+  width: 100%;
+  max-width: none;
+  min-width: 0;
+}
+
+.client-directory-filters {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.client-directory-filters .filter-select {
+  width: 100%;
+  min-width: 0;
+}
+
+.client-create-btn {
+  justify-content: center;
+  width: 100%;
+}
+
+.client-directory-list {
+  overflow: auto;
+  min-height: 0;
+}
+
+.client-directory-status {
+  padding: 22px 16px;
+  color: #697386;
+  font-size: 13px;
+}
+
+.client-directory-item {
+  display: block;
+  width: 100%;
+  padding: 13px 16px;
+  border: 0;
+  border-bottom: 1px solid #eef1f5;
+  border-left: 3px solid transparent;
+  background: #ffffff;
+  color: #111827;
+  text-align: left;
+  cursor: pointer;
+}
+
+.client-directory-item:hover {
+  background: #f9fafb;
+}
+
+.client-directory-item.active {
+  border-left-color: #6d28d9;
+  background: #f1f2f5;
+}
+
+.client-directory-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.client-directory-name strong {
+  overflow: hidden;
+  color: #111827;
+  font-size: 13px;
+  font-weight: 800;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.client-directory-name span,
+.abbr-tag {
+  display: inline-flex;
+  align-items: center;
+  min-height: 18px;
+  padding: 1px 6px;
+  border: 1px solid #d7dce5;
+  border-radius: 4px;
+  background: #f3f5f8;
+  color: #697386;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.client-directory-en {
+  overflow: hidden;
+  margin-top: 4px;
+  color: #40506a;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.client-directory-meta {
+  overflow: hidden;
+  margin-top: 2px;
+  color: #7b8798;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.client-profile-surface {
+  height: 100%;
+  overflow: auto;
+  min-width: 0;
+  background: #f8f9fb;
+}
+
+.client-profile {
+  min-height: 100%;
+  padding: 18px 28px 40px;
+}
+
+.client-profile-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid #dfe4ec;
+}
+
+.client-profile-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.client-profile-title-row h1 {
+  margin: 0;
+  color: #111827;
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
+.client-profile-header p {
+  margin: 5px 0 0;
+  color: #697386;
+  font-size: 12px;
+}
+
+.client-profile-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.btn-danger {
+  display: inline-flex;
+  align-items: center;
+  height: 36px;
+  padding: 0 16px;
+  border: 1px solid #b42318;
+  border-radius: 6px;
+  background: #d92d20;
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.btn-danger:hover {
+  background: #b42318;
+}
+
+.btn-compact {
+  height: 30px;
+  padding: 0 10px;
+  font-size: 12px;
+}
+
+.client-danger-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 14px;
+  padding: 10px 12px;
+  border: 1px solid #d6bbfb;
+  border-radius: 4px;
+  background: #f8f4ff;
+  color: #6d28d9;
+  font-size: 12px;
+}
+
+.client-profile-section {
+  padding-top: 28px;
+}
+
+.client-profile-section h3 {
+  margin: 0 0 18px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #dfe4ec;
+  color: #111827;
+  font-size: 15px;
+  font-weight: 800;
+}
+
+.client-profile-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 20px 64px;
+}
+
+.client-info-cell {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.client-info-cell.wide {
+  grid-column: 1 / -1;
+}
+
+.client-info-cell span {
+  color: #98a2b3;
+  font-size: 12px;
+  line-height: 1.25;
+}
+
+.client-info-cell small {
+  color: #c0c7d2;
+  font-size: 11px;
+  line-height: 1.25;
+}
+
+.client-info-cell strong {
+  overflow-wrap: anywhere;
+  color: #344054;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.client-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(17, 24, 39, 0.36);
+}
+
+.client-create-modal {
+  width: min(640px, 100%);
+  overflow: hidden;
+  border: 1px solid #e1e6ef;
+  border-radius: 14px;
+  background: #ffffff;
+  box-shadow: 0 22px 48px rgba(15, 23, 42, 0.22);
+}
+
+.client-create-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 22px 28px 16px;
+  border-bottom: 1px solid #eef1f5;
+}
+
+.client-create-modal-header h2 {
+  margin: 0;
+  color: #111827;
+  font-size: 19px;
+  font-weight: 800;
+}
+
+.client-create-modal-header span {
+  display: block;
+  margin-top: 2px;
+  color: #8a94a6;
+  font-size: 13px;
+}
+
+.client-modal-close {
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: #8a94a6;
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+}
+
+.client-modal-close:hover {
+  background: #f3f5f8;
+  color: #344054;
+}
+
+.client-create-modal-body {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px 18px;
+  padding: 22px 28px;
+}
+
+.client-modal-field {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.client-modal-field span {
+  color: #40506a;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.client-create-error {
+  margin: 0 28px 16px;
+  padding: 10px 12px;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  background: #fff1f2;
+  color: #b42318;
+  font-size: 12px;
+}
+
+.client-create-modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 18px 28px;
+  border-top: 1px solid #eef1f5;
+  background: #ffffff;
+}
+
+.client-create-modal-footer .btn-primary,
+.client-create-modal-footer .btn-secondary {
+  min-width: 130px;
+  justify-content: center;
+}
+
 .client-toolbar {
   display: flex;
   align-items: center;
@@ -466,4 +860,50 @@
 .wizard-footer-right {
   display: flex;
   gap: 8px;
+}
+
+@media (max-width: 0) {
+  .client-workspace {
+    grid-template-columns: 1fr;
+    margin: -16px;
+  }
+
+  .client-directory {
+    max-height: 420px;
+    border-right: 0;
+    border-bottom: 1px solid #d9dee8;
+  }
+
+  .client-profile {
+    padding: 18px 16px 32px;
+  }
+
+  .client-profile-header {
+    flex-direction: column;
+  }
+
+  .client-profile-actions {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 0) {
+  .client-profile-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .client-create-modal-body {
+    grid-template-columns: 1fr;
+  }
+
+  .client-create-modal-footer {
+    align-items: stretch;
+    flex-direction: column-reverse;
+  }
+
+  .client-danger-banner {
+    align-items: flex-start;
+    flex-direction: column;
+  }
 }

--- a/frontend/src/features/clients/routes.tsx
+++ b/frontend/src/features/clients/routes.tsx
@@ -1,6 +1,5 @@
 import { NAVIGATION_BY_ID } from '../../app/navigation'
 import type { AppRouteConfig } from '../../app/router'
-import { ClientDetailPage } from './pages/ClientDetailPage'
 import { ClientFormPage } from './pages/ClientFormPage'
 import { ClientListPage } from './pages/ClientListPage'
 
@@ -18,7 +17,7 @@ export const clientRoutes: AppRouteConfig[] = [
   {
     path: '/clients/:id',
     routeId: 'clients.detail',
-    element: <ClientDetailPage />,
+    element: <ClientListPage />,
   },
   {
     path: '/clients/:id/edit',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,11 +2,16 @@
   box-sizing: border-box;
 }
 
+:root {
+  --app-min-width: 1280px;
+}
+
 html,
 body,
 #root {
   margin: 0;
   width: 100%;
+  min-width: var(--app-min-width);
   min-height: 100%;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
     Cantarell, 'Helvetica Neue', sans-serif;
@@ -15,4 +20,5 @@ body,
 
 body {
   background: #f4f5f7;
+  overflow-x: auto;
 }

--- a/frontend/src/shared/layout/AppLayout.css
+++ b/frontend/src/shared/layout/AppLayout.css
@@ -1,6 +1,7 @@
 /* â”€â”€ Layout: shared across all pages â”€â”€ */
 
 :root {
+  --app-min-width: 1280px;
   --bg-page: #f0f0f0;
   --bg-sidebar: #f5f5f5;
   --bg-main: #ffffff;
@@ -17,9 +18,9 @@
 
 .app {
   display: flex;
-  width: 100%;
+  width: max(100vw, var(--app-min-width));
   height: 100vh;
-  min-width: 1200px;
+  min-width: var(--app-min-width);
   overflow: hidden;
   font-family: 'PingFang SC', 'Microsoft YaHei', 'Helvetica Neue', Arial, sans-serif;
   font-size: 14px;


### PR DESCRIPTION
## Summary

This PR builds out the Manager-facing Client and Case Management frontend experiences.

### Client Management

- Reworked the Clients page into a split-view workspace:
  - Left panel for searchable/filterable client directory
  - Right panel for selected client profile details
- Added independent scrolling between the client list and profile panel.
- Updated `/clients/:id` to reuse the split-view layout and auto-select the matching client.
- Added a modal-based “New Monastic” creation flow instead of navigating to a separate page.
- Added Manager actions for:
  - Link Contacts
  - Edit Profile
  - Delete placeholder/confirmation banner
- Preserved permission checks for create/update/delete/full-profile access.

### Case Management

- Replaced the placeholder Case page with a functional management list.
- Added search and filters for:
  - Case number / monastic name
  - Status
  - Caseworker
- Added reusable Case components:
  - `CaseToolbar`
  - `CaseTable`
  - `CaseStatusBadge`
  - `CaseIntensityDot`
- Added `useCases` query hook for case list/detail/create flows.
- Added status badges and intensity indicators matching the audit/manager table style.
- Adjusted the Case page to use fluid width so it adapts to available page space.

### Layout

- Added a global app minimum width via `--app-min-width`.
- Prevented narrow browser windows from reflowing key management layouts.
- Small windows now preserve layout and use horizontal scrolling instead of collapsing the UI.

## Testing

- Ran `npm run build` successfully.
- Rebuilt and restarted the Docker frontend container with:

```bash
docker compose -f infra/docker/docker-compose.yaml up -d --build frontend