### PR TITLE
feat/Report模块新增delete

### DIFF
--- a/backend/src/main/java/aranya/crm/controller/ReportController.java
+++ b/backend/src/main/java/aranya/crm/controller/ReportController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -45,5 +46,11 @@ public class ReportController {
     ) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(reportService.createReport(request, currentUser));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteReport(@PathVariable Long id) {
+        reportService.deleteReport(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/aranya/crm/service/ReportService.java
+++ b/backend/src/main/java/aranya/crm/service/ReportService.java
@@ -68,6 +68,14 @@ public class ReportService {
         return toReportDetailResponse(visitReportRepository.save(report));
     }
 
+    @Transactional
+    public void deleteReport(Long reportId) {
+        VisitReport report = visitReportRepository.findById(reportId)
+                .orElseThrow(() -> new EntityNotFoundException("Report not found: " + reportId));
+
+        visitReportRepository.delete(report);
+    }
+
     private ReportSummaryResponse toReportSummaryResponse(VisitReport report) {
         Client client = report.getClient();
         User createdBy = report.getCreatedBy();

--- a/backend/src/test/java/aranya/crm/service/ReportServiceTest.java
+++ b/backend/src/test/java/aranya/crm/service/ReportServiceTest.java
@@ -173,6 +173,27 @@ class ReportServiceTest {
                 .hasMessage("Client not found: 99");
     }
 
+    @Test
+    @DisplayName("deleteReport removes an existing report")
+    void deleteReport_removesExistingReport() {
+        VisitReport report = report(1L, client(5L, "Venerable Dev Test", "测试法师"), user(9L, "YiKai Kong"));
+        when(visitReportRepository.findById(1L)).thenReturn(Optional.of(report));
+
+        reportService.deleteReport(1L);
+
+        verify(visitReportRepository).delete(report);
+    }
+
+    @Test
+    @DisplayName("deleteReport throws when report does not exist")
+    void deleteReport_throwsWhenReportDoesNotExist() {
+        when(visitReportRepository.findById(404L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> reportService.deleteReport(404L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("Report not found: 404");
+    }
+
     private static CreateReportRequest createRequest() {
         CreateReportRequest request = new CreateReportRequest();
         request.setClientId(5L);

--- a/frontend/src/features/reports/api/report.api.ts
+++ b/frontend/src/features/reports/api/report.api.ts
@@ -15,3 +15,7 @@ export async function createReport(data: CreateReportPayload): Promise<ReportDet
   const res = await http.post<ReportDetail>('/v1/reports', data)
   return res.data
 }
+
+export async function deleteReport(id: string | number): Promise<void> {
+  await http.delete(`/v1/reports/${id}`)
+}

--- a/frontend/src/features/reports/pages/ReportDetailPage.tsx
+++ b/frontend/src/features/reports/pages/ReportDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { BackButton, ErrorBanner, PageHeader, SectionCard } from '../../../shared/ui'
-import { fetchReportById } from '../api/report.api'
+import { deleteReport, fetchReportById } from '../api/report.api'
 import type { ReportDetail } from '../types'
 import './reports.css'
 
@@ -65,6 +65,7 @@ export function ReportDetailPage() {
   const navigate = useNavigate()
   const [report, setReport] = useState<ReportDetail>()
   const [isLoading, setIsLoading] = useState(true)
+  const [isDeleting, setIsDeleting] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string>()
 
   useEffect(() => {
@@ -108,6 +109,24 @@ export function ReportDetailPage() {
     return `RPT-${String(report.id).padStart(4, '0')}`
   }, [report])
 
+  async function handleDelete() {
+    if (!report) return
+
+    const confirmed = window.confirm(`确认删除报告 RPT-${String(report.id).padStart(4, '0')}？ / Delete this report?`)
+    if (!confirmed) return
+
+    setIsDeleting(true)
+    setErrorMessage(undefined)
+
+    try {
+      await deleteReport(report.id)
+      navigate('/reports')
+    } catch {
+      setErrorMessage('探访报告删除失败，请稍后重试。 / Failed to delete report.')
+      setIsDeleting(false)
+    }
+  }
+
   if (isLoading) {
     return (
       <div className="report-page">
@@ -136,6 +155,49 @@ export function ReportDetailPage() {
         descriptionZh={`提交人：${displayText(report.createdByName ?? report.staffName, 'Unknown')}`}
         descriptionEn={`Created at ${formatDate(report.createdAt ?? report.reportTimestamp)}`}
       />
+
+      {errorMessage ? <ErrorBanner message={errorMessage} /> : null}
+
+      <SectionCard className="report-action-card" ariaLabel="Report actions" bodyPadding>
+        <div className="report-action-header">
+          <div>
+            <h2>探访报告</h2>
+            <p>
+              Observation Report · Submitted by: {displayText(report.createdByName ?? report.staffName, 'Unknown')} · {formatDate(report.dateOfVisit)}
+            </p>
+          </div>
+          <div className="report-status-stack">
+            <span className="report-status-submitted">Submitted</span>
+            <span className="report-status-urgent">⚠ 紧急 · Urgent</span>
+          </div>
+        </div>
+
+        <div className="report-detail-actions">
+          <button className="report-action-danger" type="button" onClick={() => window.alert('Mock only: resolve flag is not implemented yet.')}>
+            处理标记 · Resolve Flag
+          </button>
+          <button className="report-action-success" type="button" onClick={() => window.alert('Mock only: approve is not implemented yet.')}>
+            审批 · Approve
+          </button>
+          <button className="report-action-secondary" type="button" onClick={() => window.alert('Mock only: archive is not implemented yet.')}>
+            归档 · Archive
+          </button>
+          <button className="report-action-delete" type="button" disabled={isDeleting} onClick={() => void handleDelete()}>
+            {isDeleting ? '删除中...' : '删除 · Delete'}
+          </button>
+        </div>
+
+        <div className="report-urgent-mock-banner">
+          <span>
+            🚨 此报告由 {displayText(report.createdByName ?? report.staffName, 'Unknown')} 标记为紧急。
+            <br />
+            This report was marked URGENT by {displayText(report.createdByName ?? report.staffName, 'Unknown')}.
+          </span>
+          <button type="button" onClick={() => window.alert('Mock only: mark resolved is not implemented yet.')}>
+            ✓ 标记为已处理 · Mark Resolved
+          </button>
+        </div>
+      </SectionCard>
 
       <SectionCard className="report-detail-card" ariaLabel="Report summary" bodyPadding>
         <div className="report-detail-grid">

--- a/frontend/src/features/reports/pages/ReportListPage.tsx
+++ b/frontend/src/features/reports/pages/ReportListPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ErrorBanner, PageHeader, SectionCard, TableShell } from '../../../shared/ui'
-import { fetchReports } from '../api/report.api'
+import { deleteReport, fetchReports } from '../api/report.api'
 import type { ReportSummary } from '../types'
 import './reports.css'
 
@@ -43,6 +43,7 @@ export function ReportListPage() {
   const [errorMessage, setErrorMessage] = useState<string>()
   const [search, setSearch] = useState('')
   const [typeFilter, setTypeFilter] = useState('all')
+  const [deletingId, setDeletingId] = useState<number>()
 
   useEffect(() => {
     let active = true
@@ -91,6 +92,23 @@ export function ReportListPage() {
       return matchesType && matchesSearch
     })
   }, [reports, search, typeFilter])
+
+  async function handleDelete(report: ReportSummary) {
+    const confirmed = window.confirm(`确认删除报告 RPT-${String(report.id).padStart(4, '0')}？ / Delete this report?`)
+    if (!confirmed) return
+
+    setDeletingId(report.id)
+    setErrorMessage(undefined)
+
+    try {
+      await deleteReport(report.id)
+      setReports((current) => current.filter((item) => item.id !== report.id))
+    } catch {
+      setErrorMessage('探访报告删除失败，请稍后重试。 / Failed to delete report.')
+    } finally {
+      setDeletingId(undefined)
+    }
+  }
 
   return (
     <div className="report-page">
@@ -182,13 +200,23 @@ export function ReportListPage() {
                       <span className="cell-main">{formatDate(report.createdAt ?? report.reportTimestamp)}</span>
                     </td>
                     <td>
-                      <button
-                        className="report-view-link"
-                        type="button"
-                        onClick={() => navigate(`/reports/${report.id}`)}
-                      >
-                        查看 · View
-                      </button>
+                      <div className="report-row-actions">
+                        <button
+                          className="report-view-link"
+                          type="button"
+                          onClick={() => navigate(`/reports/${report.id}`)}
+                        >
+                          查看 · View
+                        </button>
+                        <button
+                          className="report-delete-link"
+                          type="button"
+                          disabled={deletingId === report.id}
+                          onClick={() => void handleDelete(report)}
+                        >
+                          删除 · Delete
+                        </button>
+                      </div>
                     </td>
                   </tr>
                 ))

--- a/frontend/src/features/reports/pages/reports.css
+++ b/frontend/src/features/reports/pages/reports.css
@@ -169,11 +169,160 @@
   color: #111827;
 }
 
+.report-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.report-delete-link {
+  border: 0;
+  background: transparent;
+  color: #dc2626;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 800;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.report-delete-link:hover:not(:disabled) {
+  color: #991b1b;
+}
+
+.report-delete-link:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 .report-table-state {
   height: 180px;
   color: #98a2b3;
   font-size: 13px;
   text-align: center;
+}
+
+.report-action-card {
+  margin-top: 18px;
+}
+
+.report-action-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.report-action-header h2 {
+  margin: 0;
+  color: #111827;
+  font-size: 28px;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.report-action-header p {
+  margin: 8px 0 0;
+  color: #667085;
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.report-status-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+  flex: 0 0 auto;
+}
+
+.report-status-submitted,
+.report-status-urgent {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  border-radius: 5px;
+  font-size: 14px;
+  font-weight: 900;
+  line-height: 1;
+  padding: 0 12px;
+}
+
+.report-status-submitted {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+.report-status-urgent {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.report-detail-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 28px;
+  flex-wrap: wrap;
+}
+
+.report-action-danger,
+.report-action-success,
+.report-action-secondary,
+.report-action-delete,
+.report-urgent-mock-banner button {
+  min-height: 40px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 900;
+  line-height: 1;
+  padding: 0 18px;
+}
+
+.report-action-danger,
+.report-action-delete {
+  border: 1px solid #dc2626;
+  background: #dc2626;
+  color: #ffffff;
+}
+
+.report-action-success,
+.report-urgent-mock-banner button {
+  border: 1px solid #2f7d3f;
+  background: #2f7d3f;
+  color: #ffffff;
+}
+
+.report-action-secondary {
+  border: 1px solid #d0d5dd;
+  background: #ffffff;
+  color: #344054;
+}
+
+.report-action-delete:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.report-urgent-mock-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-top: 18px;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  background: #fff7f7;
+  color: #b91c1c;
+  font-size: 14px;
+  line-height: 1.45;
+  padding: 14px 16px;
+}
+
+.report-urgent-mock-banner button {
+  flex: 0 0 auto;
 }
 
 .report-detail-card {
@@ -326,7 +475,7 @@
 .col-report-visit-date { width: 13%; }
 .col-report-type { width: 14%; }
 .col-report-created-at { width: 13%; }
-.col-report-actions { width: 12%; }
+.col-report-actions { width: 14%; }
 
 @media (max-width: 1100px) {
   .report-detail-grid {
@@ -353,6 +502,22 @@
 
   .report-detail-grid {
     grid-template-columns: 1fr;
+  }
+
+  .report-action-header,
+  .report-urgent-mock-banner {
+    display: block;
+  }
+
+  .report-status-stack {
+    align-items: flex-start;
+    margin-top: 16px;
+  }
+
+  .report-detail-actions button,
+  .report-urgent-mock-banner button {
+    width: 100%;
+    margin-top: 10px;
   }
 
   .report-form-grid {


### PR DESCRIPTION
后端新增 DELETE /api/v1/reports/{id}
ReportService 新增 deleteReport(id)，删除前会先查 report，不存在则抛 Report not found ReportServiceTest 新增删除相关单测
前端 report.api.ts 新增 deleteReport
Reports 列表每行新增 删除 · Delete 按钮
Report detail 顶部新增截图里的操作区：
处理标记 · Resolve Flag：mock-only 提示
审批 · Approve：mock-only 提示
归档 · Archive：mock-only 提示
删除 · Delete：真实调用删除 API
Submitted / Urgent 状态和 urgent banner 先用前端 mock 展示
删除行为：
列表页删除成功后，会从当前列表移除该 report。
详情页删除成功后，会跳回 /reports。
删除前有浏览器 confirm 确认。
已验证：
npm run build 通过
ReportServiceTest 通过：8 tests, 0 failures