### PR TITLE
feat(client): add create client with case

### DIFF
--- a/backend/src/main/java/aranya/crm/controller/ClientController.java
+++ b/backend/src/main/java/aranya/crm/controller/ClientController.java
@@ -1,17 +1,27 @@
 package aranya.crm.controller;
 
+import aranya.crm.dto.request.CreateClientRequest;
+import aranya.crm.dto.request.UpdateClientRequest;
 import aranya.crm.dto.response.ClientDetailResponse;
 import aranya.crm.dto.response.ClientSummaryResponse;
+import aranya.crm.entity.User;
+import aranya.crm.security.annotation.CurrentUser;
 import aranya.crm.service.ClientService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import java.net.URI;
 import java.util.List;
 
 @RestController
@@ -33,5 +43,28 @@ public class ClientController {
     @GetMapping("/{id}")
     public ResponseEntity<ClientDetailResponse> getClientDetail(@PathVariable Long id) {
         return ResponseEntity.ok(clientService.getClientDetail(id));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('MANAGER')")
+    public ResponseEntity<ClientDetailResponse> createClient(
+            @Valid @RequestBody CreateClientRequest req,
+            @CurrentUser User currentUser
+    ) {
+        ClientDetailResponse created = clientService.createClient(req, currentUser);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(created.getId())
+                .toUri();
+        return ResponseEntity.created(location).body(created);
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasRole('MANAGER')")
+    public ResponseEntity<ClientDetailResponse> updateClient(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateClientRequest req
+    ) {
+        return ResponseEntity.ok(clientService.updateClient(id, req));
     }
 }

--- a/backend/src/main/java/aranya/crm/entity/Client.java
+++ b/backend/src/main/java/aranya/crm/entity/Client.java
@@ -9,6 +9,7 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -17,6 +18,7 @@ import java.time.LocalDateTime;
 @Setter
 @Entity
 @Table(name = "client")
+@DynamicUpdate
 public class Client {
 
     @Id

--- a/backend/src/main/java/aranya/crm/repository/CaseRepository.java
+++ b/backend/src/main/java/aranya/crm/repository/CaseRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface CaseRepository extends JpaRepository<ClientCase, Long> {
 
@@ -59,4 +60,9 @@ public interface CaseRepository extends JpaRepository<ClientCase, Long> {
     );
 
     long countByStatusNotAndColorCodeIn(String status, Collection<String> colorCodes);
+
+    @Query("SELECT cc.caseCode FROM ClientCase cc " +
+           "WHERE cc.caseCode LIKE CONCAT('ASDFL/', :year, '/C/%') " +
+           "ORDER BY cc.id DESC LIMIT 1")
+    Optional<String> findLatestCaseCodeByYear(@Param("year") String year);
 }

--- a/backend/src/main/java/aranya/crm/service/ClientService.java
+++ b/backend/src/main/java/aranya/crm/service/ClientService.java
@@ -1,11 +1,15 @@
 package aranya.crm.service;
 
+import aranya.crm.dto.request.CreateClientRequest;
 import aranya.crm.dto.request.UpdateClientRequest;
 import aranya.crm.dto.response.ClientDetailResponse;
 import aranya.crm.dto.response.ClientSummaryResponse;
 import aranya.crm.dto.response.RelatedContactResponse;
 import aranya.crm.entity.Client;
+import aranya.crm.entity.ClientCase;
 import aranya.crm.entity.RelatedContact;
+import aranya.crm.entity.User;
+import aranya.crm.repository.CaseRepository;
 import aranya.crm.repository.ClientRepository;
 import aranya.crm.repository.RelatedContactRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -13,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -22,6 +27,7 @@ import java.util.function.Consumer;
 public class ClientService {
 
     private final ClientRepository clientRepository;
+    private final CaseRepository caseRepository;
     private final RelatedContactRepository relatedContactRepository;
 
     public List<ClientSummaryResponse> listClients(String q, String membershipStatus) {
@@ -42,6 +48,43 @@ public class ClientService {
         return clients.stream()
                 .map(this::toClientSummaryResponse)
                 .toList();
+    }
+
+    @Transactional
+    public ClientDetailResponse createClient(CreateClientRequest req, User createdBy) {
+        Client client = new Client();
+        client.setNameEn(req.getNameEn());
+        client.setNameChn(req.getNameChn());
+        client.setAbbr(req.getAbbr());
+        client.setBuddhistTradition(req.getBuddhistTradition());
+        client.setOrdinationStatus(req.getOrdinationStatus());
+        client.setAreaDistrict(req.getAreaDistrict());
+        client.setPreferredLanguage(req.getPreferredLanguage());
+        client.setContact(req.getContact());
+        clientRepository.save(client);
+
+        // 同步新增case,一个client对应一个长期维护的case
+        ClientCase clientCase = new ClientCase();
+        clientCase.setClient(client);
+        clientCase.setCreatedBy(createdBy);
+        clientCase.setCaseCode(generateCaseCode());
+        clientCase.setTitle(client.getNameEn() + " - Initial Case");
+        clientCase.setColorCode(req.getColorCode());
+        clientCase.setTradition(req.getBuddhistTradition());
+        caseRepository.save(clientCase);
+
+        return getClientDetail(client.getId());
+    }
+
+    private String generateCaseCode() {
+        String year = String.valueOf(LocalDate.now().getYear());
+        return caseRepository.findLatestCaseCodeByYear(year)
+                .map(latest -> {
+                    String[] parts = latest.split("/");
+                    int next = Integer.parseInt(parts[parts.length - 1]) + 1;
+                    return String.format("ASDFL/%s/C/%03d", year, next);
+                })
+                .orElse(String.format("ASDFL/%s/C/001", year));
     }
 
     @Transactional

--- a/backend/src/test/java/aranya/crm/controller/ClientControllerTest.java
+++ b/backend/src/test/java/aranya/crm/controller/ClientControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -24,8 +25,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -121,6 +127,125 @@ class ClientControllerTest {
     @DisplayName("Anonymous user cannot get client detail")
     void getClientDetail_returns403_forAnonymousUser() throws Exception {
         mockMvc.perform(get("/api/v1/clients/10"))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── createClient ────────────────────────────────────────────────────────
+
+    private static final String VALID_CREATE_BODY = """
+            {"nameEn":"John Smith","abbr":"JS","buddhistTradition":"Mahayana"}
+            """;
+
+    @Test
+    @DisplayName("Manager can create a client — 201 with Location header")
+    @WithMockUser(roles = "MANAGER")
+    void createClient_returns201_forManager() throws Exception {
+        when(clientService.createClient(any(), any())).thenReturn(
+                ClientDetailResponse.builder()
+                        .id(20L)
+                        .abbr("JS")
+                        .nameEn("John Smith")
+                        .membershipStatus("ACTIVE")
+                        .createdAt(LocalDateTime.of(2026, 5, 21, 10, 0))
+                        .relatedContacts(List.of())
+                        .build()
+        );
+
+        mockMvc.perform(post("/api/v1/clients")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_CREATE_BODY))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", org.hamcrest.Matchers.endsWith("/api/v1/clients/20")))
+                .andExpect(jsonPath("$.id").value(20))
+                .andExpect(jsonPath("$.abbr").value("JS"));
+    }
+
+    @Test
+    @DisplayName("Social Worker cannot create a client — 403")
+    @WithMockUser(roles = "SOCIAL_WORKER")
+    void createClient_returns403_forSocialWorker() throws Exception {
+        mockMvc.perform(post("/api/v1/clients")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_CREATE_BODY))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Volunteer cannot create a client — 403")
+    @WithMockUser(roles = "VOLUNTEER")
+    void createClient_returns403_forVolunteer() throws Exception {
+        mockMvc.perform(post("/api/v1/clients")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_CREATE_BODY))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Anonymous user cannot create a client — 403")
+    void createClient_returns403_forAnonymousUser() throws Exception {
+        mockMvc.perform(post("/api/v1/clients")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_CREATE_BODY))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Missing required fields returns 400")
+    @WithMockUser(roles = "MANAGER")
+    void createClient_returns400_whenRequiredFieldsMissing() throws Exception {
+        mockMvc.perform(post("/api/v1/clients")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── updateClient ─────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Manager can update a client — 200")
+    @WithMockUser(roles = "MANAGER")
+    void updateClient_returns200_forManager() throws Exception {
+        when(clientService.updateClient(eq(10L), any())).thenReturn(
+                ClientDetailResponse.builder()
+                        .id(10L)
+                        .abbr("C001")
+                        .nameEn("Updated Name")
+                        .membershipStatus("ACTIVE")
+                        .createdAt(LocalDateTime.of(2026, 5, 7, 9, 30))
+                        .relatedContacts(List.of())
+                        .build()
+        );
+
+        mockMvc.perform(patch("/api/v1/clients/10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"nameEn":"Updated Name"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(10))
+                .andExpect(jsonPath("$.nameEn").value("Updated Name"));
+    }
+
+    @Test
+    @DisplayName("Volunteer cannot update a client — 403")
+    @WithMockUser(roles = "VOLUNTEER")
+    void updateClient_returns403_forVolunteer() throws Exception {
+        mockMvc.perform(patch("/api/v1/clients/10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"nameEn":"Updated Name"}
+                                """))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Anonymous user cannot update a client — 403")
+    void updateClient_returns403_forAnonymousUser() throws Exception {
+        mockMvc.perform(patch("/api/v1/clients/10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"nameEn":"Updated Name"}
+                                """))
                 .andExpect(status().isForbidden());
     }
 }


### PR DESCRIPTION
## PR Summary

### Changes
- Implement `createClient` and `updateClient` service methods in `ClientService`
- Add `POST /api/v1/clients` and `PATCH /api/v1/clients/{id}` REST endpoints to `ClientController`
- Add `findLatestCaseCodeByYear` query to `CaseRepository` for sequential case code generation
- Fill `CreateClientRequest` and `UpdateClientRequest` DTOs with full field definitions and validation annotations
- Rename frontend `Client` type fields to align with backend naming conventions across all client feature files

### Technical Details
- `createClient()` creates a `Client` and an associated `ClientCase` in a single `@Transactional` block; case code is auto-generated in `ASDFL/{YEAR}/C/{NNN}` format (3-digit zero-padded, derived from `findLatestCaseCodeByYear`)
- `updateClient()` uses PATCH semantics: null fields are skipped via a `Consumer<T>` helper; entity uses `@DynamicUpdate` to limit DB writes to changed columns
- `POST /api/v1/clients` returns `201 Created` with `Location: /api/v1/clients/{id}` header and full `ClientDetailResponse` body
- `PATCH /api/v1/clients/{id}` returns `200 OK` with full `ClientDetailResponse` body
- Both write endpoints are gated with `@PreAuthorize("hasRole('MANAGER')")` at method level, overriding the class-level `isAuthenticated()`
- Frontend `WellbeingDomain` union: removed `substanceUse`, renamed `spiritualWellbeing` → `spiritual`; `bankTransferInfo`/`payNowInfo` changed from `boolean` to `string`

### Impact
- **Backend**: `ClientController`, `ClientService`, `CaseRepository`, `CreateClientRequest`, `UpdateClientRequest` — non-breaking; existing GET endpoints unchanged
- **Frontend**: `types.ts`, `client.api.ts`, `ClientDetailTabs.tsx`, `ClientFormSteps.tsx`, `ClientFormPage.tsx`, `ClientListPage.tsx`, `ClientTable.tsx`, `client.mock.ts` — field renames are breaking within the feature module but isolated to `features/clients/`

### Testing
- 8 new `@WebMvcTest` cases added to `ClientControllerTest`: auth/role guards for `createClient` (MANAGER→201, SOCIAL_WORKER/VOLUNTEER/anonymous→403, missing fields→400) and `updateClient` (MANAGER→200, VOLUNTEER/anonymous→403)
- Full stack rebuilt and verified via Docker Compose; all three services (postgres, backend, frontend) confirmed `Up`
