### PR TITLE
docs: update api-spec and developer-guide for client write APIs and o…

### DIFF
--- a/docs/System Design/01-api-spec.md
+++ b/docs/System Design/01-api-spec.md
@@ -2,7 +2,7 @@
 
 This document summarizes the API and backend service surface implemented in the current branch.
 
-Last updated: 2026-05-19
+Last updated: 2026-05-21
 
 ## 1. Backend Summary
 
@@ -23,7 +23,7 @@ Implemented backend services:
 | `UserService` | Current-user profile, local user listing, invite stub, role updates, status updates, soft delete, Firebase profile sync | Implemented |
 | `UiManifestService` | Builds route/feature/widget capability lists from local role-permission records | Implemented |
 | `DashboardService` | Builds role-aware dashboard sections from clients, cases, and visit reports | Implemented |
-| `ClientService` | Lists clients, filters by search/status, returns client details and related contacts | Implemented, read-only |
+| `ClientService` | Lists clients, filters by search/status, returns client details and related contacts; creates and updates clients | Implemented |
 | `CaseService` | Lists cases, filters by search/status, returns case details, and provides active/urgent case data for dashboard | Implemented, read-only |
 
 Implemented HTTP API groups:
@@ -34,13 +34,11 @@ Implemented HTTP API groups:
 | UI manifest | `GET /api/v1/ui/manifest` |
 | Dashboard | `GET /api/v1/dashboard` |
 | Users | `GET /api/v1/users`, `POST /api/v1/users/invite`, `PATCH /api/v1/users/{id}/roles`, `PATCH /api/v1/users/{id}/status`, `DELETE /api/v1/users/{id}` |
-| Clients | `GET /api/v1/clients`, `GET /api/v1/clients/{id}` |
+| Clients | `GET /api/v1/clients`, `GET /api/v1/clients/{id}`, `POST /api/v1/clients`, `PATCH /api/v1/clients/{id}` |
 | Cases | `GET /api/v1/cases`, `GET /api/v1/cases/{id}` |
 
 Not implemented as backend HTTP APIs yet:
 
-- `POST /api/v1/clients`
-- `PUT /api/v1/clients/{id}`
 - `POST /api/v1/cases`
 - `GET /api/v1/cases/{caseId}/notes`
 - `POST /api/v1/cases/{caseId}/notes`
@@ -429,11 +427,14 @@ Response:
 
 ## 9. Client API
 
-The current backend implements read-only client APIs.
-
 Authorization:
 
-- Authenticated Firebase user
+| Endpoint | Required role |
+| --- | --- |
+| `GET /api/v1/clients` | Authenticated user |
+| `GET /api/v1/clients/{id}` | Authenticated user |
+| `POST /api/v1/clients` | `ROLE_MANAGER` |
+| `PATCH /api/v1/clients/{id}` | `ROLE_MANAGER` |
 
 ### GET `/api/v1/clients`
 
@@ -545,6 +546,89 @@ Notes:
 - Missing client ids result in an `EntityNotFoundException`; global error mapping should be confirmed before relying on a final HTTP shape.
 - The frontend currently treats all client membership status values as `Active` and does not expose membership-status filtering in the client profile page.
 
+### POST `/api/v1/clients`
+
+Creates a new client and atomically creates an initial `ClientCase` in the same transaction.
+
+Authorization: `ROLE_MANAGER`
+
+Request:
+
+```json
+{
+  "nameEn": "Venerable Hui Ming",
+  "nameChn": "慧明法师",
+  "abbr": "HM",
+  "buddhistTradition": "Theravada",
+  "ordinationStatus": "Ordained",
+  "areaDistrict": "Central",
+  "preferredLanguage": "EN",
+  "contact": "91234567",
+  "colorCode": "GREEN"
+}
+```
+
+Validation:
+
+| Field | Required | Constraints |
+| --- | --- | --- |
+| `nameEn` | Yes | Max 150 |
+| `abbr` | Yes | Max 20 |
+| `nameChn` | No | Max 100 |
+| `buddhistTradition` | No | Max 50 |
+| `ordinationStatus` | No | Max 30 |
+| `areaDistrict` | No | Max 100 |
+| `preferredLanguage` | No | Max 50 |
+| `contact` | No | Max 20 |
+| `colorCode` | No | Max 20; used as the initial case color — `GREEN`, `YELLOW`, `ORANGE`, `RED` |
+
+Response: `201 Created` with `Location: /api/v1/clients/{id}` header; body is the full `ClientDetailResponse`.
+
+Notes:
+
+- The initial case title is set to `{nameEn} - Initial Case`.
+- `caseCode` is auto-generated in format `ASDFL/{YEAR}/C/{NNN}` (3-digit zero-padded, e.g. `ASDFL/2026/C/001`). The sequence resets at the start of each calendar year.
+- The authenticated manager is recorded as `createdBy` on the initial case.
+
+### PATCH `/api/v1/clients/{id}`
+
+Partially updates an existing client profile.
+
+Authorization: `ROLE_MANAGER`
+
+All fields are optional. Only non-null fields in the request body are applied — absent and explicit `null` fields leave the existing value unchanged.
+
+Request fields mirror the full `ClientDetailResponse` profile (all `String`, `Boolean`, and `LocalDate` fields on the `Client` entity are patchable). Key fields include:
+
+```json
+{
+  "nameEn": "Updated Name",
+  "nameChn": "更新名字",
+  "abbr": "UN",
+  "contact": "91234567",
+  "preferredCommunication": "WHATSAPP",
+  "whatsappEnabled": true,
+  "preferredLanguage": "EN",
+  "spokenLanguage": "English",
+  "addressText": "123 Example Street",
+  "postalCode": "123456",
+  "areaDistrict": "Central",
+  "gender": "FEMALE",
+  "dateOfBirth": "1980-01-01",
+  "buddhistTradition": "Theravada",
+  "ordinationStatus": "Ordained",
+  "wellbeingPhysicalHealth": true,
+  "membershipRemarks": "Remarks"
+}
+```
+
+Response: `200 OK` with the full updated `ClientDetailResponse`.
+
+Notes:
+
+- Uses `@DynamicUpdate` on the entity; only changed columns are written to the database.
+- Missing client id results in an `EntityNotFoundException`.
+
 ## 10. Case API
 
 The current backend implements read-only case APIs.
@@ -612,9 +696,6 @@ Notes:
 The frontend contains service modules for clients, cases, reports, and auth support. The backend currently does not expose the following planned endpoints:
 
 ```http
-POST /api/v1/clients
-PUT /api/v1/clients/{id}
-
 POST /api/v1/cases
 GET /api/v1/cases/{caseId}/notes
 POST /api/v1/cases/{caseId}/notes
@@ -636,7 +717,41 @@ POST /api/v1/auth/2fa/*
 
 Firebase Authentication and MFA enrollment/challenge are handled by the frontend through Firebase.
 
-## 12. OpenAPI UI
+## 12. Observability
+
+### Spring Boot Admin
+
+Runtime monitoring UI for the backend JVM, health indicators, log levels, and HTTP traces.
+
+| URL | Service |
+| --- | --- |
+| `http://localhost:9090` | Spring Boot Admin (Docker or local admin-server) |
+
+The backend registers itself with the admin server at startup using `SPRING_BOOT_ADMIN_URL`. All actuator endpoints are exposed (`management.endpoints.web.exposure.include: "*"`).
+
+### SonarQube (Docker profile)
+
+Code quality and coverage reporting. Activated via `--profile sonar`:
+
+```powershell
+docker compose -f infra/docker/docker-compose.yaml --profile sonar up -d sonar-postgres sonarqube
+```
+
+Then run the scanner:
+
+```powershell
+docker compose -f infra/docker/docker-compose.yaml --profile sonar run --rm sonar-scanner
+```
+
+| URL | Service |
+| --- | --- |
+| `http://localhost:9000` | SonarQube UI |
+
+Requires `SONAR_TOKEN` to be set before running the scanner (generate via SonarQube UI → My Account → Security → Tokens).
+
+Coverage data is produced by JaCoCo (`prepare-agent` + `report` on the `verify` phase) and read by the `sonar-maven-plugin`.
+
+## 13. OpenAPI UI
 
 When the backend is running, Swagger UI should be available at:
 

--- a/docs/System Design/developer-guide.md
+++ b/docs/System Design/developer-guide.md
@@ -18,7 +18,8 @@ Current implementation status:
 - Backend uses the local database for CRM users, roles, permissions, and account status.
 - Dashboard API reads current client, case, and report summary data.
 - User-management APIs exist for managers, with limitations noted below.
-- Client and case read APIs exist. Client and case frontend services still keep mock fallback behavior for local development.
+- Client read APIs exist. Client create and update APIs are implemented (MANAGER-only). Client frontend services still keep mock fallback behavior for local development.
+- Case read APIs exist. Case frontend services still keep mock fallback behavior for local development.
 - Report pages exist in the frontend and still rely on mock/fallback behavior.
 
 ## 2. Repository Layout
@@ -146,6 +147,8 @@ Implemented backend endpoints:
 - `DELETE /api/v1/users/{id}`
 - `GET /api/v1/clients`
 - `GET /api/v1/clients/{id}`
+- `POST /api/v1/clients` (MANAGER only — creates client + initial case atomically)
+- `PATCH /api/v1/clients/{id}` (MANAGER only)
 - `GET /api/v1/cases`
 - `GET /api/v1/cases/{id}`
 
@@ -161,7 +164,7 @@ Important limitations:
 
 - Backend does not expose custom login, refresh-token, logout, or custom 2FA APIs.
 - User invite currently creates only a local database user. It does not create a Firebase Auth user or assign `firebase_uid`.
-- Client create/update APIs are not complete yet.
+- Client create/update APIs are implemented. Case write, notes, and status-history APIs are not complete yet.
 - Case create, notes, and status-history APIs are not complete yet.
 - Report backend APIs are not complete yet.
 
@@ -394,6 +397,7 @@ Expected URLs:
 
 - frontend: `http://localhost`
 - backend: `http://localhost:8080`
+- admin server: `http://localhost:9090`
 - postgres: `localhost:5432`
 
 How traffic works in Docker:
@@ -679,11 +683,14 @@ Backend Docker build:
 
 ### Compose notes
 
-Current compose file starts:
+Default compose services (always-on):
 
 - `postgres`
+- `admin-server` (Spring Boot Admin, port 9090)
 - `backend`
 - `frontend`
+
+The `sonar` Docker Compose profile adds `sonar-postgres`, `sonarqube`, and `sonar-scanner`. These are resource-heavy and opt-in only — they do not start with the default `up -d`.
 
 Backend container configuration:
 
@@ -692,30 +699,74 @@ Backend container configuration:
 - sets `FIREBASE_SERVICE_ACCOUNT_PATH=file:/run/secrets/firebase-service-account-dev.json`
 - bind-mounts the local service account JSON as read-only
 
-## 15. Known Issues And Risks
+## 15. Observability
+
+### Spring Boot Admin
+
+Spring Boot Admin provides a runtime UI for the backend: JVM metrics, health indicators, active HTTP traces, log-level overrides, and environment properties.
+
+| URL | Available when |
+| --- | --- |
+| `http://localhost:9090` | `admin-server` container is running |
+
+The `admin-server` is always started as part of the default Docker Compose stack. The backend auto-registers with it via `SPRING_BOOT_ADMIN_URL: http://admin-server:9090` in the compose environment.
+
+Source: `admin-server/` module — Spring Boot 3 + `@EnableAdminServer`.
+
+### SonarQube and JaCoCo (Code Coverage)
+
+JaCoCo is wired into the Maven build (`jacoco-maven-plugin`). It instruments tests and generates `target/site/jacoco/jacoco.xml` on the `verify` phase.
+
+SonarQube reads this report and uploads coverage data. It runs as a Docker Compose profile so it does not consume resources during normal development.
+
+#### First-time setup
+
+1. Start SonarQube:
+
+```powershell
+docker compose -f infra/docker/docker-compose.yaml --profile sonar up -d sonar-postgres sonarqube
+```
+
+2. Open `http://localhost:9000`, log in with `admin` / `admin`, change the password when prompted.
+
+3. Generate a scanner token: My Account → Security → Generate Token (type: Global Analysis).
+
+4. Set the token in your environment:
+
+```powershell
+$env:SONAR_TOKEN="<your-token>"
+```
+
+#### Running a scan
+
+```powershell
+docker compose -f infra/docker/docker-compose.yaml --profile sonar run --rm sonar-scanner
+```
+
+The scanner service mounts `backend/` as its workspace, runs `mvn clean verify sonar:sonar`, and uploads results to the local SonarQube instance. Testcontainers-based integration tests work inside this container via Docker socket mount and `TESTCONTAINERS_HOST_OVERRIDE`.
+
+## 16. Known Issues And Risks
 
 - User invite does not create or link Firebase Auth users yet.
 - Some legacy JWT/custom 2FA config and DTO/test artifacts may still exist while the Firebase migration is being cleaned up.
-- Client write APIs are incomplete.
 - Case write, notes, and status-history APIs are incomplete.
 - Report backend APIs are incomplete.
 - Role and permission UI is moving toward `/api/v1/ui/manifest`; individual backend endpoints must still enforce authorization.
 - Service account JSON is required locally but must never be committed or baked into images.
 - Firebase TOTP MFA must be enabled at the Firebase/Identity Platform project level, otherwise enrollment returns `auth/operation-not-allowed`.
 
-## 16. Recommended Next Improvements
+## 17. Recommended Next Improvements
 
 - Clean up remaining legacy JWT and custom 2FA code/tests/config once Firebase auth is stable.
 - Add a proper admin flow to create Firebase Auth users and link local `users.firebase_uid`.
 - Add `.env.example` files for frontend and backend.
 - Add integration tests for `FirebaseAuthFilter` behavior.
-- Add client write APIs.
 - Add case write, notes, status-history, and assignment-aware authorization APIs.
 - Add report backend APIs.
 - Expand route wiring so all frontend pages are consistently reachable.
 - Add account settings for re-enrolling or removing TOTP factors through Firebase.
 
-## 17. Quick Start For New Contributors
+## 18. Quick Start For New Contributors
 
 Fastest path to a working local stack:
 
@@ -740,5 +791,7 @@ docker compose -f infra/docker/docker-compose.yaml up -d --build
 8. Open:
 
 ```text
-http://localhost
+http://localhost          # frontend
+http://localhost:8080     # backend API
+http://localhost:9090     # Spring Boot Admin
 ```


### PR DESCRIPTION
## PR Summary

### Changes
- Implement `POST /api/v1/clients` (MANAGER-only) — atomically creates `Client` + initial `ClientCase` in one transaction with auto-generated `caseCode` (`ASDFL/{YEAR}/C/{NNN}`)
- Implement `PATCH /api/v1/clients/{id}` (MANAGER-only) — partial update with PATCH semantics via `Consumer<T>` null-guard pattern
- Integrate Spring Boot Admin (`admin-server` module, port 9090) for runtime JVM/health/log monitoring
- Integrate SonarQube + JaCoCo code coverage reporting via Docker Compose `sonar` profile (no local Maven required)
- Supplement `ClientServiceTest` and `ClientControllerTest`; add `CaseServiceTest` from scratch (78 tests total)
- Fix `AuthControllerTest` returning 403 instead of 401 for unauthenticated requests
- Update `01-api-spec.md` and `developer-guide.md` to reflect all new APIs and observability stack

### Technical Details
- `CaseRepository.findLatestCaseCodeByYear`: JPQL query with `ORDER BY cc.id DESC` to avoid lexicographic string comparison pitfall when generating sequential case codes
- `ClientService.createClient`: `@Transactional`, saves `Client` then `ClientCase`; `generateCaseCode()` parses last segment of latest code and zero-pads with `String.format("ASDFL/%s/C/%03d", year, next)`
- `Client` entity annotated with `@DynamicUpdate` so `PATCH` only writes changed columns
- `admin-server`: standalone Spring Boot 3 module with `@EnableAdminServer`; multi-stage Docker build; always-on compose service
- SonarQube compose services (`sonar-postgres`, `sonarqube`, `sonar-scanner`) gated behind `profiles: ["sonar"]`; scanner mounts Docker socket + sets `TESTCONTAINERS_HOST_OVERRIDE` for Testcontainers-in-Docker support
- JaCoCo `prepare-agent` + `report` (verify phase) generates `jacoco.xml` consumed by `sonar-maven-plugin`
- `TestSecurityConfig` in `AuthControllerTest` now registers a custom `authenticationEntryPoint` returning `SC_UNAUTHORIZED` (fixes default Spring Security behavior of returning 403)

### Impact
- `ClientController`: two new write endpoints added (non-breaking to existing read endpoints)
- `SecurityConfig`: public path widened from `/actuator/health` to `/actuator/**` to expose all actuator endpoints to Spring Boot Admin
- Docker Compose: `admin-server` added as a default service; `backend` depends on it at startup
- No schema migrations required (client and case tables already exist)

### Testing
- 78 backend unit tests pass (`mvn clean verify` via `sonar-scanner` Docker service confirmed)
- `ClientServiceTest`: 7 new cases covering `listClients` (search/no-search), `createClient` (first code, sequential code, field mapping), `updateClient` (partial update, field isolation)
- `CaseServiceTest`: 13 new cases covering `listCases`, `getCaseDetail`, `resolveTradition`
- `ClientControllerTest`: 8 new cases covering `POST` (201, 403×3, 400) and `PATCH` (200, 403×2)
- SonarQube scan completed; coverage report uploaded to local instance
