### PR TITLE
feat: Add production backend deployment configuration

### DIFF
--- a/.github/workflows/deploy-backend-gcp.yaml
+++ b/.github/workflows/deploy-backend-gcp.yaml
@@ -1,0 +1,88 @@
+name: Deploy Backend to GCP
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/**"
+      - "infra/docker/docker-compose.backend.prod.yaml"
+      - "scripts/deploy-backend.sh"
+      - ".github/workflows/deploy-backend-gcp.yaml"
+
+concurrency:
+  group: deploy-backend-gcp
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  GCP_REGION: ${{ secrets.GCP_REGION }}
+  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  GCP_ARTIFACT_REPOSITORY: ${{ secrets.GCP_ARTIFACT_REPOSITORY }}
+  IMAGE_NAME: backend
+  REMOTE_APP_DIR: ${{ secrets.GCP_REMOTE_APP_DIR || '/opt/aranya-crm' }}
+  SSH_PORT: ${{ secrets.GCP_SSH_PORT || '22' }}
+
+jobs:
+  deploy:
+    name: Build, push, and deploy backend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          token_format: access_token
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker "${GCP_REGION}-docker.pkg.dev" --quiet
+
+      - name: Build backend image
+        run: |
+          set -euo pipefail
+          image="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/${IMAGE_NAME}:${GITHUB_SHA}"
+          docker build -t "$image" backend
+          echo "BACKEND_IMAGE=$image" >> "$GITHUB_ENV"
+
+      - name: Push backend image
+        run: docker push "$BACKEND_IMAGE"
+
+      - name: Prepare SSH
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.GCP_SSH_PRIVATE_KEY }}" > ~/.ssh/gcp_vm_key
+          chmod 600 ~/.ssh/gcp_vm_key
+          ssh-keyscan -p "$SSH_PORT" "${{ secrets.GCP_VM_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Sync deployment files to VM
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/gcp_vm_key -p "$SSH_PORT" "${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }}" "mkdir -p '$REMOTE_APP_DIR'"
+          scp -i ~/.ssh/gcp_vm_key -P "$SSH_PORT" infra/docker/docker-compose.backend.prod.yaml "${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }}:$REMOTE_APP_DIR/docker-compose.backend.prod.yaml"
+          scp -i ~/.ssh/gcp_vm_key -P "$SSH_PORT" scripts/deploy-backend.sh "${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }}:$REMOTE_APP_DIR/deploy-backend.sh"
+          ssh -i ~/.ssh/gcp_vm_key -p "$SSH_PORT" "${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }}" "chmod +x '$REMOTE_APP_DIR/deploy-backend.sh'"
+
+      - name: Authenticate VM Docker to Artifact Registry
+        run: |
+          set -euo pipefail
+          printf '%s' '${{ steps.auth.outputs.access_token }}' | ssh -i ~/.ssh/gcp_vm_key -p "$SSH_PORT" "${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }}" \
+            "docker login -u oauth2accesstoken --password-stdin https://${GCP_REGION}-docker.pkg.dev"
+
+      - name: Deploy backend on VM
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/gcp_vm_key -p "$SSH_PORT" "${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }}" \
+            "APP_DIR='$REMOTE_APP_DIR' '$REMOTE_APP_DIR/deploy-backend.sh' '$BACKEND_IMAGE'"

--- a/infra/docker/docker-compose.backend.prod.yaml
+++ b/infra/docker/docker-compose.backend.prod.yaml
@@ -1,0 +1,24 @@
+services:
+  backend:
+    image: ${BACKEND_IMAGE}
+    container_name: aranya_crm_backend_prod
+    restart: unless-stopped
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      DB_HOST: ${DB_HOST}
+      DB_PORT: ${DB_PORT:-5432}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      FIREBASE_PROJECT_ID: ${FIREBASE_PROJECT_ID}
+      FIREBASE_SERVICE_ACCOUNT_PATH: file:/run/secrets/firebase-service-account.json
+      JWT_SECRET: ${JWT_SECRET}
+      TWO_FACTOR_ENCRYPTION_KEY: ${TWO_FACTOR_ENCRYPTION_KEY}
+      APP_CORS_ALLOWED_ORIGINS: ${APP_CORS_ALLOWED_ORIGINS}
+      TZ: ${TZ:-Asia/Singapore}
+    ports:
+      - "${BACKEND_PORT:-8080}:8080"
+    volumes:
+      - type: bind
+        source: ./secrets/firebase-service-account.json
+        target: /run/secrets/firebase-service-account.json
+        read_only: true

--- a/scripts/deploy-backend.sh
+++ b/scripts/deploy-backend.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="${APP_DIR:-/opt/aranya-crm}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.backend.prod.yaml}"
+ENV_FILE="${ENV_FILE:-.env}"
+IMAGE="${1:-${BACKEND_IMAGE:-}}"
+
+if [ -z "$IMAGE" ]; then
+  echo "Usage: BACKEND_IMAGE=<image> $0"
+  echo "   or: $0 <image>"
+  exit 64
+fi
+
+cd "$APP_DIR"
+
+if [ ! -f "$COMPOSE_FILE" ]; then
+  echo "Missing compose file: $APP_DIR/$COMPOSE_FILE"
+  exit 66
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Missing environment file: $APP_DIR/$ENV_FILE"
+  exit 66
+fi
+
+if [ ! -f "secrets/firebase-service-account.json" ]; then
+  echo "Missing Firebase service account: $APP_DIR/secrets/firebase-service-account.json"
+  exit 66
+fi
+
+export BACKEND_IMAGE="$IMAGE"
+
+echo "Deploying backend image: $BACKEND_IMAGE"
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull backend
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d backend
+
+echo "Waiting for backend health check..."
+for attempt in $(seq 1 30); do
+  if curl -fsS "http://localhost:${BACKEND_PORT:-8080}/actuator/health" >/dev/null; then
+    echo "Backend is healthy."
+    docker image prune -f
+    exit 0
+  fi
+
+  echo "Health check attempt $attempt failed; retrying..."
+  sleep 5
+done
+
+echo "Backend did not become healthy in time."
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" logs --tail=120 backend
+exit 1


### PR DESCRIPTION
- docker-compose.backend.prod.yaml: Production-grade Docker Compose configuration for backend service, defines containerized backend runtime with environment-based database host/credentials, Firebase config, JWT secrets, CORS settings, and health check port binding.

- scripts/deploy-backend.sh: Deployment automation script that validates prerequisites (compose file, env file, Firebase credentials), pulls latest backend image, starts container, and performs health checks via actuator endpoint to ensure service availability before cleanup.

- .github/workflows/deploy-backend-gcp.yaml: CI/CD pipeline triggered on main branch changes or manual dispatch, orchestrates backend image build → push to GCP Artifact Registry → SSH sync deployment files to VM → Docker login → remote deployment execution via deploy-backend.sh script.