### PR TITLE
Feature/194 integrate with google share calendar

### DIFF
--- a/backend/src/main/java/aranya/crm/controller/CaseController.java
+++ b/backend/src/main/java/aranya/crm/controller/CaseController.java
@@ -157,6 +157,27 @@ public class CaseController {
         return ResponseEntity.ok(caseService.createServiceEvent(id, request, currentUser));
     }
 
+    @PatchMapping("/{id}/service-events/{eventId}")
+    @PreAuthorize("@capEval.hasCap(authentication, 'cases:services.create')")
+    public ResponseEntity<ServiceEventResponse> updateServiceEvent(
+            @PathVariable Long id,
+            @PathVariable Long eventId,
+            @Valid @RequestBody CreateServiceEventRequest request,
+            @CurrentUser User currentUser
+    ) {
+        return ResponseEntity.ok(caseService.updateServiceEvent(id, eventId, request, currentUser));
+    }
+
+    /** 手动重试将本地事件同步到 Google 共享日历(上次镜像失败时使用)。 */
+    @PostMapping("/{id}/service-events/{eventId}/sync")
+    @PreAuthorize("@capEval.hasCap(authentication, 'cases:services.create')")
+    public ResponseEntity<ServiceEventResponse> syncServiceEvent(
+            @PathVariable Long id,
+            @PathVariable Long eventId
+    ) {
+        return ResponseEntity.ok(caseService.syncServiceEvent(id, eventId));
+    }
+
     @DeleteMapping("/{id}/service-events/{eventId}")
     @PreAuthorize("@capEval.hasCap(authentication, 'cases:services.create')")
     public ResponseEntity<Void> deleteServiceEvent(

--- a/backend/src/main/java/aranya/crm/dto/response/ServiceEventResponse.java
+++ b/backend/src/main/java/aranya/crm/dto/response/ServiceEventResponse.java
@@ -37,4 +37,8 @@ public class ServiceEventResponse {
     private String schedule;
     private String manpower;
     private String instructions;
+    // Google 共享日历镜像状态:true=已同步(存在 google_event_id)
+    private boolean synced;
+    // 该事件当前镜像所在的日历 id(用于编辑时预选,避免误移动)
+    private String googleCalendarId;
 }

--- a/backend/src/main/java/aranya/crm/service/CaseService.java
+++ b/backend/src/main/java/aranya/crm/service/CaseService.java
@@ -183,6 +183,7 @@ public class CaseService {
         if (serviceKey == null || !selected.contains(serviceKey)) {
             throw new IllegalArgumentException("Service is not selected for this case");
         }
+        validateEventTimes(request.getScheduledStart(), request.getScheduledEnd());
 
         // 负责人可空;给定时校验可分配性
         Long assignedId = null;
@@ -238,24 +239,135 @@ public class CaseService {
                 createdBy.getId());
 
         ServiceEventResponse response = findServiceEventById(eventId);
-        // best-effort 镜像到 Google 共享日历;按组织模板拼标题与正文;失败不阻断本地创建
-        String title = composeEventTitle(eventSeq, response);
-        String description = composeEventDescription(request);
-        String targetCalendarId = trimToNull(request.getCalendarId());
-        String resolvedCalendarId = googleCalendarService.resolveTargetCalendarId(targetCalendarId);
-        googleCalendarService.createCaseEvent(
-                        caseId,
-                        response.getServiceKey(),
-                        title,
-                        description,
-                        venue,
-                        request.getScheduledStart(),
-                        request.getScheduledEnd(),
-                        targetCalendarId)
-                .ifPresent(googleEventId -> jdbcTemplate.update(
-                        "UPDATE service_appointment SET google_event_id = ?, google_calendar_id = ? WHERE id = ?",
-                        googleEventId, resolvedCalendarId, eventId));
-        return response;
+        // best-effort 镜像到 Google 共享日历;失败不阻断本地创建
+        mirrorToGoogle(eventId, caseId, response, trimToNull(request.getCalendarId()), null, null);
+        // 重新读取使 synced 反映镜像结果
+        return findServiceEventById(eventId);
+    }
+
+    /** 编辑已存在的服务事件:更新本地真相源,并同步更新/补建 Google 镜像。 */
+    public ServiceEventResponse updateServiceEvent(Long caseId, Long eventId,
+                                                   CreateServiceEventRequest request, User currentUser) {
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(
+                "SELECT google_event_id, google_calendar_id FROM service_appointment WHERE id = ? AND case_id = ?",
+                eventId, caseId);
+        if (rows.isEmpty()) {
+            throw new EntityNotFoundException("Service event not found: " + eventId);
+        }
+        ClientCase clientCase = caseRepository.findById(caseId)
+                .orElseThrow(() -> new EntityNotFoundException("Case not found: " + caseId));
+        Set<String> selected = selectedServiceKeySet(caseId);
+        String serviceKey = trimToNull(request.getServiceKey());
+        if (serviceKey == null || !selected.contains(serviceKey)) {
+            throw new IllegalArgumentException("Service is not selected for this case");
+        }
+        validateEventTimes(request.getScheduledStart(), request.getScheduledEnd());
+
+        Long assignedId = null;
+        if (request.getAssignedUserId() != null) {
+            User assigned = userRepository.findByIdWithRoles(request.getAssignedUserId())
+                    .orElseThrow(() -> new EntityNotFoundException("User not found: " + request.getAssignedUserId()));
+            requireAssignable(currentUser, assigned);
+            assignedId = assigned.getId();
+        }
+        Long serviceTypeId = findServiceTypeId(serviceKey);
+        String venue = resolveVenue(request.getLocation(), clientCase);
+
+        jdbcTemplate.update("""
+                UPDATE service_appointment SET
+                    service_type_id = ?,
+                    scheduled_start = ?,
+                    scheduled_end = ?,
+                    report_due_at = ?,
+                    location = ?,
+                    work_description = ?,
+                    notes = ?,
+                    agenda = ?,
+                    schedule = ?,
+                    manpower = ?,
+                    instructions = ?,
+                    address = ?,
+                    assigned_user_id = ?
+                WHERE id = ? AND case_id = ?
+                """,
+                serviceTypeId,
+                request.getScheduledStart(),
+                request.getScheduledEnd(),
+                request.getReportDueAt(),
+                venue,
+                normalizeText(request.getWorkDescription()),
+                normalizeText(request.getNotes()),
+                normalizeText(request.getAgenda()),
+                normalizeText(request.getSchedule()),
+                normalizeText(request.getManpower()),
+                normalizeText(request.getInstructions()),
+                normalizeText(request.getAddress()),
+                assignedId,
+                eventId, caseId);
+
+        ServiceEventResponse updated = findServiceEventById(eventId);
+        mirrorToGoogle(eventId, caseId, updated, trimToNull(request.getCalendarId()),
+                asString(rows.get(0).get("google_event_id")),
+                asString(rows.get(0).get("google_calendar_id")));
+        return findServiceEventById(eventId);
+    }
+
+    /** 手动重试将事件同步到 Google(用于上次镜像失败的事件);保持其原目标日历。 */
+    public ServiceEventResponse syncServiceEvent(Long caseId, Long eventId) {
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(
+                "SELECT google_event_id, google_calendar_id FROM service_appointment WHERE id = ? AND case_id = ?",
+                eventId, caseId);
+        if (rows.isEmpty()) {
+            throw new EntityNotFoundException("Service event not found: " + eventId);
+        }
+        ServiceEventResponse ev = findServiceEventById(eventId);
+        String existingCalendar = asString(rows.get(0).get("google_calendar_id"));
+        mirrorToGoogle(eventId, caseId, ev, existingCalendar,
+                asString(rows.get(0).get("google_event_id")), existingCalendar);
+        return findServiceEventById(eventId);
+    }
+
+    /**
+     * 将事件镜像到 Google(best-effort)。existing* 为空表示尚未镜像→新建;
+     * 已镜像且目标日历变更→先删旧再新建;否则原地更新。镜像结果写回 google_event_id/calendar_id。
+     */
+    private void mirrorToGoogle(Long eventId, Long caseId, ServiceEventResponse ev, String requestedCalendarId,
+                                String existingGoogleEventId, String existingGoogleCalendarId) {
+        String title = composeEventTitle(ev.getEventSeq(), ev);
+        String description = composeEventDescriptionFromEvent(ev);
+        String targetCalendarId = googleCalendarService.resolveTargetCalendarId(requestedCalendarId);
+
+        // 目标日历变了:删除旧日历上的镜像,转为新建
+        if (existingGoogleEventId != null && existingGoogleCalendarId != null
+                && !existingGoogleCalendarId.equals(targetCalendarId)) {
+            googleCalendarService.deleteCaseEvent(existingGoogleCalendarId, existingGoogleEventId);
+            existingGoogleEventId = null;
+        }
+
+        if (existingGoogleEventId != null) {
+            googleCalendarService.updateCaseEvent(targetCalendarId, existingGoogleEventId, caseId,
+                            ev.getServiceKey(), title, description, ev.getLocation(),
+                            ev.getScheduledStart(), ev.getScheduledEnd())
+                    .ifPresent(gid -> jdbcTemplate.update(
+                            "UPDATE service_appointment SET google_event_id = ?, google_calendar_id = ? WHERE id = ?",
+                            gid, targetCalendarId, eventId));
+        } else {
+            googleCalendarService.createCaseEvent(caseId, ev.getServiceKey(), title, description,
+                            ev.getLocation(), ev.getScheduledStart(), ev.getScheduledEnd(), targetCalendarId)
+                    .ifPresent(gid -> jdbcTemplate.update(
+                            "UPDATE service_appointment SET google_event_id = ?, google_calendar_id = ? WHERE id = ?",
+                            gid, targetCalendarId, eventId));
+        }
+    }
+
+    private void validateEventTimes(LocalDateTime start, LocalDateTime end) {
+        if (start != null && end != null && end.isBefore(start)) {
+            throw new IllegalArgumentException("End time must not be before start time");
+        }
+    }
+
+    private String asString(Object value) {
+        return value == null ? null : value.toString();
     }
 
     /** 组织日历标题:`072 Medical Appointment: VKZhi @ Address` */
@@ -272,13 +384,13 @@ public class CaseService {
     }
 
     /** 组织日历正文:按 *Agenda* / *Schedule* / *Address* / *Manpower* / *Instructions for Kappiya* 分节。 */
-    private String composeEventDescription(CreateServiceEventRequest request) {
+    private String composeEventDescriptionFromEvent(ServiceEventResponse ev) {
         StringBuilder sb = new StringBuilder();
-        appendSection(sb, "Agenda", request.getAgenda());
-        appendSection(sb, "Schedule", request.getSchedule());
-        appendSection(sb, "Address", request.getAddress());
-        appendSection(sb, "Manpower", request.getManpower());
-        appendSection(sb, "Instructions for Kappiya", request.getInstructions());
+        appendSection(sb, "Agenda", ev.getAgenda());
+        appendSection(sb, "Schedule", ev.getSchedule());
+        appendSection(sb, "Address", ev.getAddress());
+        appendSection(sb, "Manpower", ev.getManpower());
+        appendSection(sb, "Instructions for Kappiya", ev.getInstructions());
         return sb.toString().trim();
     }
 
@@ -531,6 +643,8 @@ public class CaseService {
                     sa.instructions,
                     sa.address,
                     sa.event_seq,
+                    sa.google_calendar_id,
+                    (sa.google_event_id IS NOT NULL) AS synced,
                     sa.scheduled_start,
                     sa.scheduled_end,
                     sa.report_due_at,
@@ -588,6 +702,8 @@ public class CaseService {
                     .schedule(rs.getString("schedule"))
                     .manpower(rs.getString("manpower"))
                     .instructions(rs.getString("instructions"))
+                    .synced(rs.getBoolean("synced"))
+                    .googleCalendarId(rs.getString("google_calendar_id"))
                     .build();
         };
     }

--- a/backend/src/main/java/aranya/crm/service/GoogleCalendarService.java
+++ b/backend/src/main/java/aranya/crm/service/GoogleCalendarService.java
@@ -3,6 +3,7 @@ package aranya.crm.service;
 import aranya.crm.config.CalendarOption;
 import aranya.crm.config.GoogleCalendarProperties;
 import aranya.crm.dto.response.CalendarEventResponse;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.util.DateTime;
 import com.google.api.services.calendar.Calendar;
 import com.google.api.services.calendar.model.Event;
@@ -97,7 +98,52 @@ public class GoogleCalendarService {
         }
     }
 
-    /** 从指定日历删除已镜像的事件;失败仅记录日志。 */
+    /**
+     * 更新指定日历上已镜像的事件(标题/时间/正文等)。
+     * @return 成功时返回 Google 事件 ID;集成未启用或失败时返回空。
+     */
+    public Optional<String> updateCaseEvent(String calendarId, String googleEventId, Long caseId, String serviceKey,
+                                            String title, String description, String location,
+                                            LocalDateTime start, LocalDateTime end) {
+        Calendar calendar = client();
+        if (calendar == null || googleEventId == null || googleEventId.isBlank() || start == null) {
+            return Optional.empty();
+        }
+        String calId = (calendarId != null && properties.isKnownCalendar(calendarId))
+                ? calendarId
+                : properties.resolveDefaultCalendarId();
+        if (calId == null) {
+            return Optional.empty();
+        }
+        try {
+            ZoneId zone = ZoneId.of(properties.getTimeZone());
+            LocalDateTime effectiveEnd = end != null ? end
+                    : start.plusMinutes(properties.getDefaultDurationMinutes());
+
+            Event event = new Event()
+                    .setSummary(title)
+                    .setDescription(description)
+                    .setLocation(location)
+                    .setColorId(properties.getEventColorId())
+                    .setStart(toEventDateTime(start, zone))
+                    .setEnd(toEventDateTime(effectiveEnd, zone));
+
+            Event.ExtendedProperties ext = new Event.ExtendedProperties();
+            ext.setShared(Map.of(
+                    CASE_ID_PROP, String.valueOf(caseId),
+                    SERVICE_KEY_PROP, serviceKey == null ? "" : serviceKey));
+            event.setExtendedProperties(ext);
+
+            Event updated = calendar.events().update(calId, googleEventId, event).execute();
+            log.info("Updated Google calendar event {} on {}", googleEventId, calId);
+            return Optional.ofNullable(updated.getId());
+        } catch (Exception e) {
+            log.warn("Failed to update Google calendar event {} on {} (continuing): {}", googleEventId, calId, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /** 从指定日历删除已镜像的事件;404/410 视为已删除,其它失败记录为潜在孤儿以便人工清理。 */
     public void deleteCaseEvent(String calendarId, String googleEventId) {
         Calendar calendar = client();
         if (calendar == null || googleEventId == null || googleEventId.isBlank()) {
@@ -112,8 +158,17 @@ public class GoogleCalendarService {
         try {
             calendar.events().delete(calId, googleEventId).execute();
             log.info("Deleted Google calendar event {} from {}", googleEventId, calId);
+        } catch (GoogleJsonResponseException e) {
+            int code = e.getStatusCode();
+            if (code == 404 || code == 410) {
+                log.info("Google calendar event {} already absent on {} (treated as deleted)", googleEventId, calId);
+            } else {
+                log.warn("Failed to delete Google calendar event {} on {} (possible orphan, manual cleanup): {}",
+                        googleEventId, calId, e.getMessage());
+            }
         } catch (Exception e) {
-            log.warn("Failed to delete Google calendar event {} (continuing): {}", googleEventId, e.getMessage());
+            log.warn("Failed to delete Google calendar event {} on {} (possible orphan, manual cleanup): {}",
+                    googleEventId, calId, e.getMessage());
         }
     }
 

--- a/docs/System Design/01-api-spec.md
+++ b/docs/System Design/01-api-spec.md
@@ -718,8 +718,20 @@ Response: array of
 
 Notes:
 
-- Backed by a Service Account; controlled by `google.calendar.*` config. When `google.calendar.enabled=false` (or credentials/calendar-id missing) it returns an empty array — the integration degrades safely and never blocks the request.
-- Case service events created via `POST /api/v1/cases/{id}/service-events` are mirrored (best-effort) to the same shared calendar and tagged with the case id via extended properties; deletion removes the mirrored event.
+- Backed by a Service Account / OAuth single account; controlled by `google.calendar.*` config. When `google.calendar.enabled=false` (or credentials/calendar-id missing) it returns an empty array — the integration degrades safely and never blocks the request.
+- Case service events created via `POST /api/v1/cases/{id}/service-events` are mirrored (best-effort) to the chosen shared calendar and tagged with the case id via extended properties; deletion removes the mirrored event.
+
+### Service event write endpoints
+
+| Method & Path | Cap | Purpose |
+|---------------|-----|---------|
+| `POST /api/v1/cases/{id}/service-events` | `cases:services.create` | Create event (local truth source + best-effort Google mirror). |
+| `PATCH /api/v1/cases/{id}/service-events/{eventId}` | `cases:services.create` | Edit event; recomposes title/body and updates the Google mirror (moves it if the target calendar changed). |
+| `POST /api/v1/cases/{id}/service-events/{eventId}/sync` | `cases:services.create` | Manually retry mirroring to Google when a previous push failed. |
+| `DELETE /api/v1/cases/{id}/service-events/{eventId}` | `cases:services.create` | Delete event; removes the Google mirror (404/410 treated as already gone). |
+
+- POST/PATCH bodies use `CreateServiceEventRequest`. `scheduledEnd`, when provided, must not be before `scheduledStart` (otherwise `400`).
+- `ServiceEventResponse` includes `synced` (true when a `google_event_id` exists) and `googleCalendarId` (the calendar the mirror currently lives on). The frontend shows a "not synced" badge + retry when integration is enabled but `synced=false`.
 
 ## 11. APIs Not Yet Implemented
 

--- a/frontend/src/features/cases/api/case.api.ts
+++ b/frontend/src/features/cases/api/case.api.ts
@@ -154,6 +154,21 @@ export async function createServiceEvent(caseId: string, data: CreateServiceEven
   return res.data
 }
 
+export async function updateServiceEvent(
+  caseId: string,
+  eventId: string | number,
+  data: CreateServiceEventPayload,
+): Promise<ServiceEvent> {
+  const res = await http.patch<ServiceEvent>(`/v1/cases/${caseId}/service-events/${eventId}`, data)
+  return res.data
+}
+
+/** 手动重试将事件同步到 Google 共享日历(上次镜像失败时)。 */
+export async function syncServiceEvent(caseId: string, eventId: string | number): Promise<ServiceEvent> {
+  const res = await http.post<ServiceEvent>(`/v1/cases/${caseId}/service-events/${eventId}/sync`)
+  return res.data
+}
+
 export async function deleteServiceEvent(caseId: string, eventId: string | number): Promise<void> {
   await http.delete(`/v1/cases/${caseId}/service-events/${eventId}`)
 }

--- a/frontend/src/features/cases/components/AddCaseEventForm.tsx
+++ b/frontend/src/features/cases/components/AddCaseEventForm.tsx
@@ -5,18 +5,28 @@ import { useQuery } from '@tanstack/react-query'
 import { fetchUsers } from '../../users/api/userManagement.api'
 import type { UserSummary } from '../../users/types'
 import { fetchCalendarOptions } from '../api/case.api'
-import { useCreateServiceEvent } from '../hooks'
-import type { Case, CaseServices } from '../types'
+import { useCreateServiceEvent, useUpdateServiceEvent } from '../hooks'
+import type { Case, CaseServices, ServiceEvent } from '../types'
 
 interface Props {
   caseData: Case
+  /** 传入则进入编辑模式,预填该事件并改走更新接口 */
+  event?: ServiceEvent
   onDone: () => void
 }
 
-/** 「增添事件」卡片弹窗 —— 按组织日历模板采集字段,创建后镜像到 Google 共享日历。 */
-export function AddCaseEventForm({ caseData, onDone }: Props) {
+/** datetime-local 需要 `YYYY-MM-DDTHH:mm`;后端返回的 ISO 串裁到分钟即可。 */
+function toLocalInput(value?: string | null): string {
+  return value ? value.slice(0, 16) : ''
+}
+
+/** 「增添/编辑事件」卡片弹窗 —— 按组织日历模板采集字段,创建/更新后镜像到 Google 共享日历。 */
+export function AddCaseEventForm({ caseData, event, onDone }: Props) {
   const { t } = useTranslation()
+  const isEdit = event != null
   const createEvent = useCreateServiceEvent(caseData.id)
+  const updateEvent = useUpdateServiceEvent(caseData.id)
+  const pending = createEvent.isPending || updateEvent.isPending
 
   const selectedServiceKeys = useMemo(
     () => (Object.keys(caseData.services) as Array<keyof CaseServices>).filter((key) => caseData.services[key]),
@@ -29,17 +39,17 @@ export function AddCaseEventForm({ caseData, onDone }: Props) {
     staleTime: 5 * 60_000,
   })
 
-  const [serviceKey, setServiceKey] = useState<keyof CaseServices | ''>(selectedServiceKeys[0] ?? '')
+  const [serviceKey, setServiceKey] = useState<keyof CaseServices | ''>(event?.serviceKey ?? selectedServiceKeys[0] ?? '')
   const [calendarId, setCalendarId] = useState('')
-  const [assignedUserId, setAssignedUserId] = useState('')
-  const [scheduledStart, setScheduledStart] = useState('')
-  const [scheduledEnd, setScheduledEnd] = useState('')
-  const [location, setLocation] = useState('')
-  const [address, setAddress] = useState('')
-  const [agenda, setAgenda] = useState('')
-  const [schedule, setSchedule] = useState('')
-  const [manpower, setManpower] = useState('')
-  const [instructions, setInstructions] = useState('')
+  const [assignedUserId, setAssignedUserId] = useState(event?.assignedUserId != null ? String(event.assignedUserId) : '')
+  const [scheduledStart, setScheduledStart] = useState(toLocalInput(event?.scheduledStart))
+  const [scheduledEnd, setScheduledEnd] = useState(toLocalInput(event?.scheduledEnd))
+  const [location, setLocation] = useState(event?.location ?? '')
+  const [address, setAddress] = useState(event?.address ?? '')
+  const [agenda, setAgenda] = useState(event?.agenda ?? '')
+  const [schedule, setSchedule] = useState(event?.schedule ?? '')
+  const [manpower, setManpower] = useState(event?.manpower ?? '')
+  const [instructions, setInstructions] = useState(event?.instructions ?? '')
   const [users, setUsers] = useState<UserSummary[]>([])
   const [formError, setFormError] = useState<string>()
 
@@ -49,40 +59,54 @@ export function AddCaseEventForm({ caseData, onDone }: Props) {
       .catch(() => {})
   }, [])
 
-  // 日历选项加载后,默认选中标记为 default 的日历
+  // 日历选项加载后:编辑模式预选事件原日历,否则选默认日历
   useEffect(() => {
     if (!calendarId && calendarOptions.length > 0) {
-      const def = calendarOptions.find((c) => c.isDefault) ?? calendarOptions[0]
+      const current = isEdit && event?.googleCalendarId
+        ? calendarOptions.find((c) => c.id === event.googleCalendarId)
+        : undefined
+      const def = current ?? calendarOptions.find((c) => c.isDefault) ?? calendarOptions[0]
       setCalendarId(def.id)
     }
-  }, [calendarOptions, calendarId])
+  }, [calendarOptions, calendarId, isEdit, event])
 
   const serviceLabel = serviceKey ? t(`cases.service.${serviceKey}`) : ''
+  const seqPrefix = event?.eventSeq != null ? `${String(event.eventSeq).padStart(3, '0')} ` : ''
   const titlePreview = serviceKey
-    ? `${serviceLabel}: ${caseData.clientAbbr ?? ''}${location.trim() ? ` @ ${location.trim()}` : ''}`
+    ? `${seqPrefix}${serviceLabel}: ${caseData.clientAbbr ?? ''}${location.trim() ? ` @ ${location.trim()}` : ''}`
     : ''
 
-  async function submit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
+  async function submit(formEvent: FormEvent<HTMLFormElement>) {
+    formEvent.preventDefault()
     setFormError(undefined)
     if (!serviceKey || !scheduledStart) {
       setFormError(t('cases.services.requiredFields'))
       return
     }
+    // 结束时间不得早于开始时间
+    if (scheduledEnd && scheduledEnd < scheduledStart) {
+      setFormError(t('cases.services.endBeforeStart'))
+      return
+    }
+    const payload = {
+      serviceKey,
+      calendarId: calendarId || undefined,
+      assignedUserId: assignedUserId || undefined,
+      scheduledStart,
+      scheduledEnd: scheduledEnd || undefined,
+      location: location.trim() || undefined,
+      address: address.trim() || undefined,
+      agenda: agenda.trim() || undefined,
+      schedule: schedule.trim() || undefined,
+      manpower: manpower.trim() || undefined,
+      instructions: instructions.trim() || undefined,
+    }
     try {
-      await createEvent.mutateAsync({
-        serviceKey,
-        calendarId: calendarId || undefined,
-        assignedUserId: assignedUserId || undefined,
-        scheduledStart,
-        scheduledEnd: scheduledEnd || undefined,
-        location: location.trim() || undefined,
-        address: address.trim() || undefined,
-        agenda: agenda.trim() || undefined,
-        schedule: schedule.trim() || undefined,
-        manpower: manpower.trim() || undefined,
-        instructions: instructions.trim() || undefined,
-      })
+      if (isEdit && event) {
+        await updateEvent.mutateAsync({ eventId: event.id, data: payload })
+      } else {
+        await createEvent.mutateAsync(payload)
+      }
       onDone()
     } catch {
       setFormError(t('cases.services.createError'))
@@ -97,7 +121,7 @@ export function AddCaseEventForm({ caseData, onDone }: Props) {
         onSubmit={submit}
       >
         <header className="event-modal-header">
-          <h2>{t('cases.services.addCalendarEvent')}</h2>
+          <h2>{isEdit ? t('cases.services.editEvent') : t('cases.services.addCalendarEvent')}</h2>
           <button type="button" className="event-modal-close" aria-label="Close" onClick={onDone}>×</button>
         </header>
 
@@ -135,13 +159,13 @@ export function AddCaseEventForm({ caseData, onDone }: Props) {
             </label>
 
             <label>
-              <span>{t('cases.services.time')}</span>
+              <span>{t('cases.services.time')} {t('cases.services.timezoneHint')}</span>
               <input type="datetime-local" value={scheduledStart} required onChange={(e) => setScheduledStart(e.target.value)} />
             </label>
 
             <label>
-              <span>{t('cases.services.endTime')}</span>
-              <input type="datetime-local" value={scheduledEnd} onChange={(e) => setScheduledEnd(e.target.value)} />
+              <span>{t('cases.services.endTime')} {t('cases.services.timezoneHint')}</span>
+              <input type="datetime-local" value={scheduledEnd} min={scheduledStart || undefined} onChange={(e) => setScheduledEnd(e.target.value)} />
             </label>
 
             <label className="wide">
@@ -205,11 +229,11 @@ export function AddCaseEventForm({ caseData, onDone }: Props) {
         </div>
 
         <footer className="event-modal-footer">
-          <button className="btn-secondary" type="button" disabled={createEvent.isPending} onClick={onDone}>
+          <button className="btn-secondary" type="button" disabled={pending} onClick={onDone}>
             {t('common.cancel')}
           </button>
-          <button className="btn-primary" type="submit" disabled={createEvent.isPending}>
-            {createEvent.isPending ? t('common.saving') : t('cases.services.createEvent')}
+          <button className="btn-primary" type="submit" disabled={pending}>
+            {pending ? t('common.saving') : isEdit ? t('common.save') : t('cases.services.createEvent')}
           </button>
         </footer>
       </form>

--- a/frontend/src/features/cases/components/CaseDetailTabs.tsx
+++ b/frontend/src/features/cases/components/CaseDetailTabs.tsx
@@ -983,7 +983,7 @@ function CalendarTab({ caseData }: { caseData: Case }) {
       <div className="case-services-section-title">
         {t('cases.services.calendarTitle')}
       </div>
-      <CaseServiceCalendar caseId={caseData.id} localEvents={caseData.serviceEvents ?? []} />
+      <CaseServiceCalendar caseData={caseData} />
 
       <div className="calendar-add-event-bar">
         <button

--- a/frontend/src/features/cases/components/CaseServiceCalendar.tsx
+++ b/frontend/src/features/cases/components/CaseServiceCalendar.tsx
@@ -5,15 +5,14 @@ import type { DatesSetArg, EventClickArg } from '@fullcalendar/core'
 import zhCnLocale from '@fullcalendar/core/locales/zh-cn'
 import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
-import type { ServiceCalendarEvent, ServiceEvent } from '../types'
-import { fetchSharedCalendarEvents } from '../api/case.api'
-import { useDeleteServiceEvent } from '../hooks'
+import type { Case, ServiceCalendarEvent, ServiceEvent } from '../types'
+import { fetchCalendarOptions, fetchSharedCalendarEvents } from '../api/case.api'
+import { useDeleteServiceEvent, useSyncServiceEvent } from '../hooks'
+import { AddCaseEventForm } from './AddCaseEventForm'
 import { EventDetailModal, type EventDetail } from './EventDetailModal'
 
 interface Props {
-  caseId: string
-  /** 本 case 自己的事件(本地真相源,完整字段) */
-  localEvents: ServiceEvent[]
+  caseData: Case
 }
 
 /** 把 Date 格式化成不带时区偏移的本地 ISO(后端按 Asia/Singapore 解析为 LocalDateTime) */
@@ -22,11 +21,15 @@ function toLocalIso(date: Date): string {
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
 }
 
-export function CaseServiceCalendar({ caseId, localEvents }: Props) {
+export function CaseServiceCalendar({ caseData }: Props) {
+  const caseId = caseData.id
+  const localEvents = caseData.serviceEvents ?? []
   const { i18n, t } = useTranslation()
   const [range, setRange] = useState<{ from: string; to: string } | null>(null)
   const [selected, setSelected] = useState<EventDetail | null>(null)
+  const [editing, setEditing] = useState<ServiceEvent | null>(null)
   const deleteEvent = useDeleteServiceEvent(caseId)
+  const syncEvent = useSyncServiceEvent(caseId)
 
   const { data: sharedEvents = [] } = useQuery({
     queryKey: ['caseSharedCalendar', caseId, range?.from, range?.to],
@@ -34,6 +37,14 @@ export function CaseServiceCalendar({ caseId, localEvents }: Props) {
     enabled: range !== null,
     staleTime: 60_000,
   })
+
+  // 集成是否启用:有可写日历即视为启用(用于决定是否展示「未同步」告警)
+  const { data: calendarOptions = [] } = useQuery({
+    queryKey: ['calendarOptions'],
+    queryFn: fetchCalendarOptions,
+    staleTime: 5 * 60_000,
+  })
+  const syncEnabled = calendarOptions.length > 0
 
   // id → 详情 的查找表(供 eventClick 用)
   const detailById = useMemo(() => {
@@ -56,6 +67,7 @@ export function CaseServiceCalendar({ caseId, localEvents }: Props) {
         instructions: ev.instructions,
         reportDueAt: ev.reportDueAt,
         localId: ev.id,
+        synced: ev.synced,
       })
     })
     sharedEvents.forEach((ev) => {
@@ -79,7 +91,7 @@ export function CaseServiceCalendar({ caseId, localEvents }: Props) {
     title: ev.title,
     start: ev.scheduledStart,
     // 月视图里不传 end:每个事件只占开始日格子,避免跨天事件横跨多列溢出(时长见详情弹窗)
-    classNames: ['evt-own'],
+    classNames: syncEnabled && ev.synced === false ? ['evt-own', 'evt-unsynced'] : ['evt-own'],
     extendedProps: { source: 'OWN_CASE' },
   }))
 
@@ -107,6 +119,18 @@ export function CaseServiceCalendar({ caseId, localEvents }: Props) {
   async function handleDelete(localId: number) {
     await deleteEvent.mutateAsync(localId)
     setSelected(null)
+  }
+
+  function handleEdit(localId: number) {
+    const ev = localEvents.find((e) => e.id === localId)
+    if (ev) {
+      setSelected(null)
+      setEditing(ev)
+    }
+  }
+
+  function handleSync(localId: number) {
+    void syncEvent.mutateAsync(localId).then(() => setSelected(null))
   }
 
   return (
@@ -145,9 +169,17 @@ export function CaseServiceCalendar({ caseId, localEvents }: Props) {
         <EventDetailModal
           detail={selected}
           onClose={() => setSelected(null)}
+          onEdit={handleEdit}
           onDelete={(id) => void handleDelete(id)}
+          onSync={handleSync}
           deleting={deleteEvent.isPending}
+          syncing={syncEvent.isPending}
+          syncEnabled={syncEnabled}
         />
+      ) : null}
+
+      {editing ? (
+        <AddCaseEventForm caseData={caseData} event={editing} onDone={() => setEditing(null)} />
       ) : null}
     </div>
   )

--- a/frontend/src/features/cases/components/EventDetailModal.tsx
+++ b/frontend/src/features/cases/components/EventDetailModal.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import DOMPurify from 'dompurify'
 
@@ -33,13 +34,19 @@ export interface EventDetail {
   description?: string | null
   calendarName?: string | null
   localId?: number
+  synced?: boolean
 }
 
 interface Props {
   detail: EventDetail
   onClose: () => void
+  onEdit?: (localId: number) => void
   onDelete?: (localId: number) => void
+  onSync?: (localId: number) => void
   deleting?: boolean
+  syncing?: boolean
+  /** Google 集成是否启用(关闭时不展示未同步告警) */
+  syncEnabled?: boolean
 }
 
 function fmt(value?: string | null): string {
@@ -58,8 +65,12 @@ function timeRange(start?: string | null, end?: string | null): string {
 }
 
 /** 像 Google Calendar 那样,点击事件后展示的详情卡片弹窗。 */
-export function EventDetailModal({ detail, onClose, onDelete, deleting }: Props) {
+export function EventDetailModal({ detail, onClose, onEdit, onDelete, onSync, deleting, syncing, syncEnabled }: Props) {
   const { t } = useTranslation()
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  const isOwn = detail.kind === 'OWN' && detail.localId != null
+  const showUnsynced = isOwn && syncEnabled && detail.synced === false
 
   const sections: Array<[string, string | null | undefined]> = [
     [t('cases.services.agenda'), detail.agenda],
@@ -90,6 +101,17 @@ export function EventDetailModal({ detail, onClose, onDelete, deleting }: Props)
             </div>
           ) : null}
 
+          {showUnsynced ? (
+            <div className="event-detail-unsynced">
+              <span>{t('cases.services.notSynced')}</span>
+              {onSync ? (
+                <button type="button" className="btn-link-action" disabled={syncing} onClick={() => onSync(detail.localId!)}>
+                  {syncing ? t('common.saving') : t('cases.services.retrySync')}
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+
           {detail.kind === 'OWN' && hasStructured ? (
             <div className="event-detail-sections">
               {sections.map(([label, value]) =>
@@ -112,19 +134,33 @@ export function EventDetailModal({ detail, onClose, onDelete, deleting }: Props)
         </div>
 
         <footer className="event-modal-footer">
-          {detail.kind === 'OWN' && detail.localId != null && onDelete ? (
-            <button
-              className="btn-danger"
-              type="button"
-              disabled={deleting}
-              onClick={() => onDelete(detail.localId!)}
-            >
-              {deleting ? t('common.saving') : t('common.delete')}
+          {isOwn && onEdit ? (
+            <button className="btn-edit" type="button" disabled={deleting} onClick={() => onEdit(detail.localId!)}>
+              {t('common.edit')}
             </button>
           ) : null}
-          <button className="btn-secondary" type="button" onClick={onClose}>
-            {t('common.cancel')}
-          </button>
+          {isOwn && onDelete ? (
+            confirmDelete ? (
+              <span className="event-detail-confirm">
+                <span>{t('cases.services.confirmDelete')}</span>
+                <button className="btn-danger" type="button" disabled={deleting} onClick={() => onDelete(detail.localId!)}>
+                  {deleting ? t('common.saving') : t('common.confirm')}
+                </button>
+                <button className="btn-secondary" type="button" disabled={deleting} onClick={() => setConfirmDelete(false)}>
+                  {t('common.cancel')}
+                </button>
+              </span>
+            ) : (
+              <button className="btn-danger" type="button" disabled={deleting} onClick={() => setConfirmDelete(true)}>
+                {t('common.delete')}
+              </button>
+            )
+          ) : null}
+          {!confirmDelete ? (
+            <button className="btn-secondary" type="button" onClick={onClose}>
+              {t('common.close')}
+            </button>
+          ) : null}
         </footer>
       </div>
     </div>

--- a/frontend/src/features/cases/hooks/index.ts
+++ b/frontend/src/features/cases/hooks/index.ts
@@ -12,6 +12,8 @@ export {
   useDeleteCaseNote,
   useDeleteServiceEvent,
   useOwnCaseNotes,
+  useSyncServiceEvent,
   useUpdateCase,
   useUpdateCaseServices,
+  useUpdateServiceEvent,
 } from './useCases'

--- a/frontend/src/features/cases/hooks/useCases.ts
+++ b/frontend/src/features/cases/hooks/useCases.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { createCase, createCaseNote, createServiceEvent, deleteCase, deleteCaseNote, deleteServiceEvent, fetchCaseAuditLog, fetchCaseById, fetchCaseFlags, fetchCaseNotes, fetchCases, updateCase, updateCaseServices } from '../api/case.api'
+import { createCase, createCaseNote, createServiceEvent, deleteCase, deleteCaseNote, deleteServiceEvent, fetchCaseAuditLog, fetchCaseById, fetchCaseFlags, fetchCaseNotes, fetchCases, syncServiceEvent, updateCase, updateCaseServices, updateServiceEvent } from '../api/case.api'
 import type { ApprovalOptions, CreateCaseNotePayload, CreateCasePayload, CreateServiceEventPayload, UpdateCasePayload } from '../api/case.api'
 import type { CaseServices } from '../types'
 
@@ -125,6 +125,31 @@ export function useCreateServiceEvent(caseId: string | undefined) {
 
   return useMutation({
     mutationFn: (data: CreateServiceEventPayload) => createServiceEvent(caseId!, data),
+    onSuccess: () => {
+      if (!caseId) return
+      queryClient.invalidateQueries({ queryKey: caseQueryKeys.detail(caseId) })
+    },
+  })
+}
+
+export function useUpdateServiceEvent(caseId: string | undefined) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ eventId, data }: { eventId: string | number; data: CreateServiceEventPayload }) =>
+      updateServiceEvent(caseId!, eventId, data),
+    onSuccess: () => {
+      if (!caseId) return
+      queryClient.invalidateQueries({ queryKey: caseQueryKeys.detail(caseId) })
+    },
+  })
+}
+
+export function useSyncServiceEvent(caseId: string | undefined) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (eventId: string | number) => syncServiceEvent(caseId!, eventId),
     onSuccess: () => {
       if (!caseId) return
       queryClient.invalidateQueries({ queryKey: caseQueryKeys.detail(caseId) })

--- a/frontend/src/features/cases/pages/cases.css
+++ b/frontend/src/features/cases/pages/cases.css
@@ -1132,6 +1132,14 @@
   color: #ffffff;
 }
 
+/* 本 case 但未同步到 Google:虚线描边提示 */
+.service-calendar-wrap .fc-event.evt-own.evt-unsynced {
+  background: #a594e8;
+  border-left: 3px solid #6a59b0;
+  outline: 1px dashed #ffffff;
+  outline-offset: -3px;
+}
+
 /* 其他 case(共享日历):浅紫弱化 + 左侧色块 */
 .service-calendar-wrap .fc-event.evt-other {
   background: #f3f1fb;
@@ -1397,6 +1405,30 @@
   color: var(--green-800);
   font-size: 11px;
   font-weight: 500;
+}
+
+/* 未同步告警条(详情弹窗内) */
+.event-detail-unsynced {
+  margin-top: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border: 1px solid #f5d9a8;
+  border-radius: 8px;
+  background: #fdf6e9;
+  color: #92610e;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+/* 删除二次确认(详情弹窗 footer) */
+.event-detail-confirm {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-main);
 }
 
 .event-detail-sections {

--- a/frontend/src/features/cases/types.ts
+++ b/frontend/src/features/cases/types.ts
@@ -49,6 +49,10 @@ export interface ServiceEvent {
   schedule?: string | null
   manpower?: string | null
   instructions?: string | null
+  // Google 共享日历镜像状态:true=已同步
+  synced?: boolean
+  // 当前镜像所在日历 id(编辑时预选)
+  googleCalendarId?: string | null
 }
 
 export const CASE_SERVICE_GROUPS: Record<keyof CaseServices, string> = {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -39,7 +39,9 @@
     "comingSoon": "Coming soon",
     "saving": "Saving...",
     "by": "by",
-    "delete": "Delete"
+    "delete": "Delete",
+    "confirm": "Confirm",
+    "close": "Close"
   },
   "approvalConfirm": {
     "title": "Approval Required",
@@ -178,12 +180,12 @@
       "search": "Search cases or members"
     },
     "service": {
-      "accommodationArrangement": "Accommodation Arrangement",
-      "deepCleaning": "Deep Cleaning",
-      "relocationAssistance": "Relocation Assistance",
-      "dailyCleaning": "Daily Cleaning",
+      "accommodationArrangement": "Lodging",
+      "deepCleaning": "Spring Cleaning",
+      "relocationAssistance": "Relocation",
+      "dailyCleaning": "Home Cleaning",
       "pestControl": "Pest Control",
-      "homeRepair": "Home Repair",
+      "homeRepair": "Handyman",
       "dailyExpenseSubsidy": "Daily Expense Subsidy",
       "cpfAssistance": "CPF Assistance",
       "mealDelivery": "Meal Delivery",
@@ -197,9 +199,15 @@
     "services": {
       "calendarTitle": "Events",
       "addCalendarEvent": "Add Event",
+      "editEvent": "Edit Event",
       "calendar": "Calendar",
       "calendarDefault": "default",
       "endTime": "End time",
+      "timezoneHint": "(SGT)",
+      "endBeforeStart": "End time must not be before start time.",
+      "confirmDelete": "Delete this event?",
+      "notSynced": "Not synced to Google Calendar",
+      "retrySync": "Retry sync",
       "agenda": "Agenda",
       "schedule": "Schedule",
       "address": "Address",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -39,7 +39,9 @@
     "comingSoon": "功能即将推出",
     "saving": "保存中...",
     "by": "by",
-    "delete": "删除"
+    "delete": "删除",
+    "confirm": "确认",
+    "close": "关闭"
   },
   "approvalConfirm": {
     "title": "需要提交审批",
@@ -197,8 +199,14 @@
     "services": {
       "calendarTitle": "事件",
       "addCalendarEvent": "增添事件",
+      "editEvent": "编辑事件",
       "calendar": "日历",
       "calendarDefault": "默认",
+      "timezoneHint": "(新加坡时间)",
+      "endBeforeStart": "结束时间不得早于开始时间。",
+      "confirmDelete": "确认删除此事件?",
+      "notSynced": "未同步到 Google 日历",
+      "retrySync": "重试同步",
       "endTime": "结束时间",
       "agenda": "议程",
       "schedule": "流程安排",

--- a/infra/gcp/cloudbuild-backend.yaml
+++ b/infra/gcp/cloudbuild-backend.yaml
@@ -15,6 +15,10 @@
 #
 # 依赖的固定命名密钥(由 bootstrap 创建):
 #   firebase-sa-dev / db-pass-dev / jwt-secret-dev
+#   gcal-oauth-client-secret / gcal-oauth-refresh-token   ← Google 日历 OAuth(机密)
+#
+# Google 日历:非机密项(开关/模式/日历列表/client_id)走下方替换变量,可在触发器覆盖;
+# 机密(client secret / refresh token)走 Secret Manager,绝不进仓库。
 
 substitutions:
   _REGION: asia-southeast1
@@ -25,6 +29,13 @@ substitutions:
   _FIREBASE_PROJECT_ID: aranya-crm-dev
   _CLOUD_SQL_CONN: ""
   _CORS_ORIGINS: ""
+  # ── Google 日历集成(非机密;机密见 --set-secrets)──
+  _GCAL_ENABLED: "true"
+  _GCAL_AUTH_MODE: OAUTH
+  _GCAL_TZ: Asia/Singapore
+  _GCAL_LIST: "c_rm92jb53d9kcdqug505764gth4@group.calendar.google.com|Aranya CASEWORK;c_fthgnknmg4o3oali8fgk11lf1c@group.calendar.google.com|Aranya METTA CARE"
+  _GCAL_DEFAULT_ID: c_rm92jb53d9kcdqug505764gth4@group.calendar.google.com
+  _GCAL_OAUTH_CLIENT_ID: 746649380908-esbcfbu0egckeuucfng3n0tococv5s4b.apps.googleusercontent.com
 
 steps:
   # 1. 构建镜像(后端构建不需要 .env,运行期靠环境变量/密钥)
@@ -57,8 +68,8 @@ steps:
       - --platform=managed
       - --allow-unauthenticated
       - --add-cloudsql-instances=${_CLOUD_SQL_CONN}
-      - --set-env-vars=^##^SPRING_PROFILES_ACTIVE=dev##FIREBASE_PROJECT_ID=${_FIREBASE_PROJECT_ID}##FIREBASE_SERVICE_ACCOUNT_PATH=file:/secrets/firebase.json##SPRING_DATASOURCE_URL=jdbc:postgresql:///${_DB_NAME}?cloudSqlInstance=${_CLOUD_SQL_CONN}&socketFactory=com.google.cloud.sql.postgres.SocketFactory##SPRING_DATASOURCE_USERNAME=${_DB_USER}##APP_CORS_ALLOWED_ORIGINS=${_CORS_ORIGINS}
-      - --set-secrets=/secrets/firebase.json=firebase-sa-dev:latest,SPRING_DATASOURCE_PASSWORD=db-pass-dev:latest,JWT_SECRET=jwt-secret-dev:latest
+      - --set-env-vars=^##^SPRING_PROFILES_ACTIVE=dev##FIREBASE_PROJECT_ID=${_FIREBASE_PROJECT_ID}##FIREBASE_SERVICE_ACCOUNT_PATH=file:/secrets/firebase.json##SPRING_DATASOURCE_URL=jdbc:postgresql:///${_DB_NAME}?cloudSqlInstance=${_CLOUD_SQL_CONN}&socketFactory=com.google.cloud.sql.postgres.SocketFactory##SPRING_DATASOURCE_USERNAME=${_DB_USER}##APP_CORS_ALLOWED_ORIGINS=${_CORS_ORIGINS}##GOOGLE_CALENDAR_ENABLED=${_GCAL_ENABLED}##GOOGLE_CALENDAR_AUTH_MODE=${_GCAL_AUTH_MODE}##GOOGLE_CALENDAR_TZ=${_GCAL_TZ}##GOOGLE_CALENDAR_LIST=${_GCAL_LIST}##GOOGLE_CALENDAR_DEFAULT_ID=${_GCAL_DEFAULT_ID}##GOOGLE_CALENDAR_OAUTH_CLIENT_ID=${_GCAL_OAUTH_CLIENT_ID}
+      - --set-secrets=/secrets/firebase.json=firebase-sa-dev:latest,SPRING_DATASOURCE_PASSWORD=db-pass-dev:latest,JWT_SECRET=jwt-secret-dev:latest,GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET=gcal-oauth-client-secret:latest,GOOGLE_CALENDAR_OAUTH_REFRESH_TOKEN=gcal-oauth-refresh-token:latest
 
 images:
   - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/backend:$SHORT_SHA

--- a/scripts/deploy-dev-backend.sh
+++ b/scripts/deploy-dev-backend.sh
@@ -26,11 +26,23 @@ DB_USER="${DB_USER:-aranya_admin}"
 SERVICE="${SERVICE:-backend-dev}"
 IMAGE_TAG="${IMAGE_TAG:-dev}"
 
+# ── Google Calendar (non-secret; override via env if needed) ─────────────────
+GCAL_ENABLED="${GCAL_ENABLED:-true}"
+GCAL_AUTH_MODE="${GCAL_AUTH_MODE:-OAUTH}"
+GCAL_TZ="${GCAL_TZ:-Asia/Singapore}"
+GCAL_LIST="${GCAL_LIST:-c_rm92jb53d9kcdqug505764gth4@group.calendar.google.com|Aranya CASEWORK;c_fthgnknmg4o3oali8fgk11lf1c@group.calendar.google.com|Aranya METTA CARE}"
+GCAL_DEFAULT_ID="${GCAL_DEFAULT_ID:-c_rm92jb53d9kcdqug505764gth4@group.calendar.google.com}"
+GCAL_OAUTH_CLIENT_ID="${GCAL_OAUTH_CLIENT_ID:-746649380908-esbcfbu0egckeuucfng3n0tococv5s4b.apps.googleusercontent.com}"
+
 # ── Required secrets (must be provided) ──────────────────────────────────────
 : "${DEV_DB_PASSWORD:?set DEV_DB_PASSWORD}"
 : "${JWT_SECRET:?set JWT_SECRET}"
 FIREBASE_SA_FILE="${FIREBASE_SA_FILE:-firebase-service-account-dev.json}"
 [ -f "$FIREBASE_SA_FILE" ] || { echo "Missing Firebase SA file: $FIREBASE_SA_FILE"; exit 66; }
+
+# ── Optional: Google Calendar OAuth secrets (calendar is enabled only when both set) ──
+#   export GCAL_OAUTH_CLIENT_SECRET='GOCSPX-...'
+#   export GCAL_OAUTH_REFRESH_TOKEN='1//0...'
 
 IMAGE="${REGION}-docker.pkg.dev/${PROJECT}/${REPO}/backend:${IMAGE_TAG}"
 
@@ -77,6 +89,17 @@ upsert_secret firebase-sa-dev < "$FIREBASE_SA_FILE"
 printf '%s' "$JWT_SECRET"       | upsert_secret jwt-secret-dev
 printf '%s' "$DEV_DB_PASSWORD"  | upsert_secret db-pass-dev
 
+# Google Calendar OAuth secrets — only when both are provided
+GCAL_READY=0
+if [ -n "${GCAL_OAUTH_CLIENT_SECRET:-}" ] && [ -n "${GCAL_OAUTH_REFRESH_TOKEN:-}" ]; then
+  printf '%s' "$GCAL_OAUTH_CLIENT_SECRET" | upsert_secret gcal-oauth-client-secret
+  printf '%s' "$GCAL_OAUTH_REFRESH_TOKEN" | upsert_secret gcal-oauth-refresh-token
+  GCAL_READY=1
+  echo "==> Google Calendar secrets upserted (integration will be enabled)"
+else
+  echo "==> (skip) GCAL_OAUTH_CLIENT_SECRET / GCAL_OAUTH_REFRESH_TOKEN not set — calendar disabled"
+fi
+
 # ── 5) Grant the Cloud Run runtime SA the roles it needs (before deploy) ─────
 PROJ_NUM="$(gcloud projects describe "$PROJECT" --format='value(projectNumber)')"
 RUNTIME_SA="${PROJ_NUM}-compute@developer.gserviceaccount.com"
@@ -91,12 +114,21 @@ gcloud builds submit backend --tag "$IMAGE"
 
 # ── 7) Deploy to Cloud Run ───────────────────────────────────────────────────
 DS_URL="jdbc:postgresql:///${DB_NAME}?cloudSqlInstance=${CONN}&socketFactory=com.google.cloud.sql.postgres.SocketFactory"
+
+# Base env vars / secrets; calendar appended when GCAL_READY=1
+ENV_VARS="^##^SPRING_PROFILES_ACTIVE=dev##FIREBASE_PROJECT_ID=${PROJECT}##FIREBASE_SERVICE_ACCOUNT_PATH=file:/secrets/firebase.json##SPRING_DATASOURCE_URL=${DS_URL}##SPRING_DATASOURCE_USERNAME=${DB_USER}"
+SECRETS="/secrets/firebase.json=firebase-sa-dev:latest,SPRING_DATASOURCE_PASSWORD=db-pass-dev:latest,JWT_SECRET=jwt-secret-dev:latest"
+if [ "$GCAL_READY" = "1" ]; then
+  ENV_VARS="${ENV_VARS}##GOOGLE_CALENDAR_ENABLED=${GCAL_ENABLED}##GOOGLE_CALENDAR_AUTH_MODE=${GCAL_AUTH_MODE}##GOOGLE_CALENDAR_TZ=${GCAL_TZ}##GOOGLE_CALENDAR_LIST=${GCAL_LIST}##GOOGLE_CALENDAR_DEFAULT_ID=${GCAL_DEFAULT_ID}##GOOGLE_CALENDAR_OAUTH_CLIENT_ID=${GCAL_OAUTH_CLIENT_ID}"
+  SECRETS="${SECRETS},GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET=gcal-oauth-client-secret:latest,GOOGLE_CALENDAR_OAUTH_REFRESH_TOKEN=gcal-oauth-refresh-token:latest"
+fi
+
 echo "==> Deploying $SERVICE"
 gcloud run deploy "$SERVICE" \
   --image "$IMAGE" --region "$REGION" --allow-unauthenticated \
   --add-cloudsql-instances "$CONN" \
-  --set-env-vars "^##^SPRING_PROFILES_ACTIVE=dev##FIREBASE_PROJECT_ID=${PROJECT}##FIREBASE_SERVICE_ACCOUNT_PATH=file:/secrets/firebase.json##SPRING_DATASOURCE_URL=${DS_URL}##SPRING_DATASOURCE_USERNAME=${DB_USER}" \
-  --set-secrets "/secrets/firebase.json=firebase-sa-dev:latest,SPRING_DATASOURCE_PASSWORD=db-pass-dev:latest,JWT_SECRET=jwt-secret-dev:latest"
+  --set-env-vars "$ENV_VARS" \
+  --set-secrets "$SECRETS"
 
 URL="$(gcloud run services describe "$SERVICE" --region "$REGION" --format='value(status.url)')"
 echo ""


### PR DESCRIPTION
## PR Summary

集成 Google 共享日历到 Case 事件,并补全事件的编辑/删除/同步能力、校验与样式;同时把日历集成接入 GCP Cloud Run 部署。

### Changes

**事件功能(A 组 + 校验)**
- 新增**编辑事件**:`PATCH /cases/{id}/service-events/{eventId}`,更新本地真相源并同步更新 Google 镜像;改目标日历时自动「旧日历删 + 新日历建」搬移。
- 详情弹窗新增**删除二次确认**,避免误删(含 Google 镜像)。
- 新增**同步失败可见性**:`ServiceEventResponse` 增加 `synced` / `googleCalendarId`;未同步事件在日历中虚线标记,详情弹窗提供「重试同步」入口。
- 新增**手动重试同步**端点:`POST /cases/{id}/service-events/{eventId}/sync`。
- 删除健壮化:Google 404/410 视为已删,其它失败记为潜在孤儿并明确日志,不阻断本地删除。
- 校验:结束时间不得早于开始时间(前端拦截 + 后端 400);时间字段标注新加坡时区(SGT)。

**文案与样式**
- i18n 英文 label 对齐 `service_type.name`(`Handyman`/`Home Cleaning`/`Relocation`/`Spring Cleaning`/`Lodging`),消除「下拉所选与生成标题不一致」。
- 日历样式:强制周日置首(中英一致)、当日改为紫色方形徽标、事件块加宽、当前 case 事件改用浅一档紫色。

**部署(GCP Cloud Run)**
- `cloudbuild-backend.yaml`、`scripts/deploy-dev-backend.sh` 接入 Google 日历 env 与 Secret(`gcal-oauth-client-secret` / `gcal-oauth-refresh-token`);非机密项(开关/模式/日历列表/默认日历/client_id)以替换变量提供默认值,机密走 Secret Manager。

### Technical Details

- **后端**:Spring Boot;`CaseService` 抽出 `mirrorToGoogle` 复用于创建/编辑/重试,正文按存储字段重组;`GoogleCalendarService` 新增 `updateCaseEvent`,删除区分 `GoogleJsonResponseException` 404/410;`CaseController` 新增 PATCH/sync 端点,沿用 `cases:services.create` 权限。
- **前端**:React + React Query;`AddCaseEventForm` 复用为编辑模式(预填、原日历预选、序号预览);新增 `useUpdateServiceEvent` / `useSyncServiceEvent`;`EventDetailModal` 增加编辑/删除确认/未同步重试;`CaseServiceCalendar` 改为接收 `caseData` 并统管编辑/同步。
- **DTO/接口**:`ServiceEventResponse` 增加 `synced`、`googleCalendarId`;`01-api-spec.md` 补充写入端点与校验说明。
- **基础设施**:Cloud Build `--set-env-vars` / `--set-secrets` 注入日历配置,运行时 SA 经项目级 `secretmanager.secretAccessor` 读取密钥。

### Impact

- 影响范围:Case 详情「事件」标签(日历、增添/编辑/删除事件、详情弹窗)、服务类型英文文案、后端事件相关接口、GCP 后端部署配置。
- 兼容性:**非破坏性**。新增接口与可选字段;旧创建/删除流程不变;部署脚本中日历为可选(未提供 OAuth 密钥时自动跳过)。

### Testing

- 前端 `npm run build`(tsc + vite)通过。
- 后端经 `docker compose build backend` 编译通过;容器启动日志确认 `Google Calendar client initialized (mode=OAUTH, calendars=[Aranya CASEWORK (default), Aranya METTA CARE])`,无 `401`/`invalid_grant`。
- 本地 Docker 全栈手动验证:创建/编辑/删除事件、未同步重试、结束早于开始被拦截、共享日历读取正常。
- `cloudbuild-backend.yaml` 通过 YAML 解析、`deploy-dev-backend.sh` 通过 `bash -n` 语法检查。
